### PR TITLE
Possible memory leak from AbstractOkCancelDialog

### DIFF
--- a/src/org/aavso/tools/vstar/ui/dialog/AbstractOkCancelDialog.java
+++ b/src/org/aavso/tools/vstar/ui/dialog/AbstractOkCancelDialog.java
@@ -50,6 +50,7 @@ abstract public class AbstractOkCancelDialog extends JDialog {
 		this.setModal(isModal);
 		this.cancelled = true;
 		this.firstUse = true;
+		this.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
 	}
 
 	public AbstractOkCancelDialog(String title) {


### PR DESCRIPTION
AbstractOkCancelDialog: setDefaultCloseOperation(DISPOSE_ON_CLOSE) added to dialog's constructor to prevent possible memory leak while closing inherited dialogs by window menu button ([x] under Windows)