### PR TITLE
SuperWASP TAMFLUX2 support

### DIFF
--- a/plugin/src/org/aavso/tools/vstar/external/plugin/SuperWASPFITSObservationSource.java
+++ b/plugin/src/org/aavso/tools/vstar/external/plugin/SuperWASPFITSObservationSource.java
@@ -19,17 +19,14 @@ package org.aavso.tools.vstar.external.plugin;
 
 import java.awt.Color;
 import java.awt.Container;
-import java.awt.Dimension;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
-import javax.swing.JButton;
-import javax.swing.JDialog;
+import javax.swing.ButtonGroup;
 import javax.swing.JPanel;
+import javax.swing.JRadioButton;
 
 import nom.tam.fits.BasicHDU;
 import nom.tam.fits.BinaryTableHDU;
@@ -49,20 +46,33 @@ import org.aavso.tools.vstar.plugin.ObservationSourcePluginBase;
 import org.aavso.tools.vstar.ui.NumberSelectionPane;
 import org.aavso.tools.vstar.ui.mediator.Mediator;
 import org.aavso.tools.vstar.util.prefs.NumericPrecisionPrefs;
+import org.aavso.tools.vstar.ui.dialog.AbstractOkCancelDialog;
+
 //12/02/2018 C. Kotnik added name to observations so they can be
 //saved and reloaded from a file.
+
+//2020-09-30: PMAK (Maksym Pyatnytskyy): 
+// 1) TAMFLUX2 support: 
+//   See https://exoplanetarchive.ipac.caltech.edu/docs/SuperWASPProcessing.html
+//   MagErrorSelectionDialog is derived from AbstractOkCancelDialog now (instead of JDialog)
+// 2) setHeliocentric(true)
+
 /**
  * A FITS file observation source plug-in that uses the Topcat FITS library.
  */
 public class SuperWASPFITSObservationSource extends ObservationSourcePluginBase {
 
+	private SeriesType superWaspSeries_raw;
 	private SeriesType superWaspSeries;
 	
-	double magErrThreshold = 0.05;
+	private double magErrThreshold = 0.05;
+	private boolean loadRaw = false;
 
 	public SuperWASPFITSObservationSource() {
 		super();
 		superWaspSeries = SeriesType.create("SuperWASP", "SuperWASP",
+				Color.RED, false, false);
+		superWaspSeries_raw = SeriesType.create("SuperWASP raw", "SuperWASP raw",
 				Color.RED, false, false);
 	}
 
@@ -85,27 +95,28 @@ public class SuperWASPFITSObservationSource extends ObservationSourcePluginBase 
 
 	@Override
 	public AbstractObservationRetriever getObservationRetriever() {
-		// Dialog moved from collectObservations() where it invoked from non-UI thread
+		// Dialog moved here from collectObservations() where it invoked from non-UI thread
 		// to this more natural place.
 		// No annoying "No observations for the specified period" messages.
 		MagErrorSelectionDialog magErrThresholdDialog = new MagErrorSelectionDialog(
-				0.01, 99.0, 0.01, magErrThreshold);
+				0.01, 99.0, 0.01, magErrThreshold, loadRaw);
 		if (magErrThresholdDialog.isCancelled()) {
 			// It seems it is safe to return null here.
 			return null;
 		};
 		magErrThreshold = magErrThresholdDialog.getValue();
+		loadRaw = magErrThresholdDialog.getLoadRaw();
 		return new FITSObservationRetriever();
 	}
 
 	@Override
 	public String getDescription() {
-		return "SuperWASP file observation reader";
+		return "SuperWASP file v2 observation reader";
 	}
 
 	@Override
 	public String getDisplayName() {
-		return "New Star from SuperWASP FITS File...";
+		return "New Star from SuperWASP FITS File v2...";
 	}
 
 	class FITSObservationRetriever extends AbstractObservationRetriever {
@@ -117,7 +128,7 @@ public class SuperWASPFITSObservationSource extends ObservationSourcePluginBase 
 		@Override
 		public void retrieveObservations() throws ObservationReadError,
 				InterruptedException {
-
+			setHeliocentric(true); // added by PMAK 2020-09-30
 			try {
 				Fits fits = new Fits(getInputStreams().get(0));
 				BasicHDU[] hdus = fits.read();
@@ -157,26 +168,36 @@ public class SuperWASPFITSObservationSource extends ObservationSourcePluginBase 
 			for (BasicHDU hdu : hdus) {
 				if (hdu instanceof BinaryTableHDU) {
 					BinaryTableHDU tableHDU = (BinaryTableHDU) hdu;
-
-					for (int row = 0; row < tableHDU.getNRows()
-							&& !wasInterrupted(); row++) {
+					
+					/*
+					System.out.println(tableHDU.getColumnName(0));
+					System.out.println(tableHDU.getColumnName(1));
+					System.out.println(tableHDU.getColumnName(2));
+					System.out.println(tableHDU.getColumnName(3));
+					System.out.println(tableHDU.getColumnName(4));
+					System.out.println(tableHDU.getColumnName(5));
+					System.out.println(tableHDU.getColumnName(6));
+					System.out.println(tableHDU.getColumnName(7));
+					*/
+					
+					int tableRows = tableHDU.getNRows();
+					for (int row = 0; row < tableRows && !wasInterrupted(); row++) {
 						try {
 							int tmid = ((int[]) tableHDU.getElement(row, 0))[0];
-							float flux = ((float[]) tableHDU.getElement(row, 1))[0];
-							float fluxErr = ((float[]) tableHDU.getElement(row,
-									2))[0];
+							float rawFlux = ((float[]) tableHDU.getElement(row, 1))[0];
+							float rawFluxErr = ((float[]) tableHDU.getElement(row, 2))[0];
 
-							float tamFlux = ((float[]) tableHDU.getElement(row,
-									3))[0];
-							float tamFluxErr = ((float[]) tableHDU.getElement(
-									row, 4))[0];
-							String imageId = (String) tableHDU.getElement(row,
-									5);
+							float tamFlux = ((float[]) tableHDU.getElement(row, 3))[0];
+							float tamFluxErr = ((float[]) tableHDU.getElement(row, 4))[0];
+							String imageId = (String) tableHDU.getElement(row, 5);
 							short ccdX = ((short[]) tableHDU.getElement(row, 6))[0];
 							short ccdY = ((short[]) tableHDU.getElement(row, 7))[0];
 							// short flag = ((short[]) tableHDU.getElement(row,
 							// 8))[0];
-
+							
+							float flux = loadRaw ? rawFlux : tamFlux;
+							float fluxErr = loadRaw ? rawFluxErr : tamFluxErr;
+							
 							if (flux > 1 && flux - fluxErr > 0) {
 								double hjd = tmid / 86400.0 + jdRef;
 								double mag = 15.0 - 2.5 * Math.log(flux)
@@ -193,14 +214,15 @@ public class SuperWASPFITSObservationSource extends ObservationSourcePluginBase 
 								ob.setName(getInputName());
 								ob.setDateInfo(new DateInfo(hjd));
 								ob.setMagnitude(new Magnitude(mag, magErr));
-								ob.setBand(superWaspSeries);
+								ob.setBand(loadRaw ? superWaspSeries_raw : superWaspSeries);
 								ob.setRecordNumber(row);
 								ob.addDetail("IMAGE_ID", imageId, "Image ID");
 								ob.addDetail("CCDX", ccdX + "", "CCD X");
 								ob.addDetail("CCDY", ccdY + "", "CCD Y");
-								ob.addDetail("FLUX", tamFlux + "", "Flux");
-								ob.addDetail("FLUXERR", tamFluxErr + "",
-										"Flux Error");
+								ob.addDetail("RAW_FLUX", rawFlux + "", "Raw Flux");
+								ob.addDetail("RAW_FLUX_ERR", rawFluxErr + "", "Raw Flux Error");
+								ob.addDetail("TAM_FLUX", tamFlux + "", "TAM Flux");
+								ob.addDetail("TAM_FLUX_ERR", tamFluxErr + "", "TAM Flux Error");
 //								ob.addDetail("FLAG", flag + "", "Flag");
 								obs.add(ob);
 							}
@@ -250,67 +272,62 @@ public class SuperWASPFITSObservationSource extends ObservationSourcePluginBase 
 	}
 
 	@SuppressWarnings("serial")
-	class MagErrorSelectionDialog extends JDialog {
+	class MagErrorSelectionDialog extends AbstractOkCancelDialog {
 
 		private NumberSelectionPane magErrorSelector;
+		private JRadioButton fitsLoadCorRadioButton;
+		private JRadioButton fitsLoadRawRadioButton;
 		
-		private boolean cancelled;
-
 		public MagErrorSelectionDialog(double min, double max,
-				double increment, double initial) {
-			super();
+				double increment, double initial, boolean loadRaw) {
+			super("Parameters");
+			
+			Container contentPane = this.getContentPane();
 			
 			cancelled = true;
-
-			setTitle("Maximum Magnitude Error");
-			setModal(true);
-			setMinimumSize(new Dimension(250, 100));
-
-			Container contentPane = this.getContentPane();
 
 			JPanel topPane = new JPanel();
 			topPane.setLayout(new BoxLayout(topPane, BoxLayout.PAGE_AXIS));
 			topPane.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
 
 			magErrorSelector = new NumberSelectionPane(
-					"Select Maximum Magnitude Error", min, max, increment,
+					"Maximum Magnitude Error", min, max, increment,
 					initial, NumericPrecisionPrefs.getMagInputFormat());
 
 			topPane.add(magErrorSelector);
+
+			topPane.add(createParameterPane());
 
 			topPane.add(createButtonPane());
 
 			contentPane.add(topPane);
 
-			this.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE); 
 			this.pack();
 			setLocationRelativeTo(Mediator.getUI().getContentPane());
 			this.setVisible(true);
 		}
 
-		protected JPanel createButtonPane() {
+		private JPanel createParameterPane() {
 			JPanel panel = new JPanel();
-			panel.setLayout(new BoxLayout(panel, BoxLayout.LINE_AXIS));
-			JButton okButton = new JButton("OK");
-			okButton.addActionListener(new ActionListener() {
-				public void actionPerformed(ActionEvent e) {
-					cancelled = false;
-					setVisible(false);
-					dispose();
-				}
-			});
-			panel.add(okButton);
+			panel.setBorder(BorderFactory.createTitledBorder("Data Version"));
 
-			this.getRootPane().setDefaultButton(okButton);
+			fitsLoadCorRadioButton = new JRadioButton("Corrected (TAMFLUX2)");
+			fitsLoadRawRadioButton = new JRadioButton("Raw (FLUX2)");
+						
+			if (!loadRaw) {
+				fitsLoadCorRadioButton.setSelected(true);
+			} else {
+				fitsLoadRawRadioButton.setSelected(true);
+			}
+						
+			ButtonGroup group = new ButtonGroup();
+			group.add(fitsLoadCorRadioButton);
+			group.add(fitsLoadRawRadioButton);
+			
+			panel.add(fitsLoadCorRadioButton);
+			panel.add(fitsLoadRawRadioButton);
 
 			return panel;
-		}
-		
-		/**
-		 * @return whether this dialog box cancelled
-		 */
-		public boolean isCancelled() {
-			return cancelled;
 		}
 
 		/**
@@ -318,6 +335,37 @@ public class SuperWASPFITSObservationSource extends ObservationSourcePluginBase 
 		 */
 		public double getValue() {
 			return magErrorSelector.getValue();
+		}
+
+		/**
+		 * 
+		 */
+		public boolean getLoadRaw() {
+			return fitsLoadRawRadioButton.isSelected();
+		}
+
+		/**
+		 * @see org.aavso.tools.vstar.ui.dialog.AbstractOkCancelDialog#cancelAction()
+		 */
+		@Override
+		protected void cancelAction() {
+			// Nothing to do.
+		}
+
+		/**
+		 * @see org.aavso.tools.vstar.ui.dialog.AbstractOkCancelDialog#okAction()
+		 */
+		@Override
+		protected void okAction() {
+			boolean ok = true;
+
+			// additional checks if needed...
+
+			if (ok) {
+				cancelled = false;
+				setVisible(false);
+				dispose();
+			}
 		}
 	}
 }

--- a/plugin/src/org/aavso/tools/vstar/external/plugin/SuperWASPFITSObservationSource.java
+++ b/plugin/src/org/aavso/tools/vstar/external/plugin/SuperWASPFITSObservationSource.java
@@ -169,17 +169,6 @@ public class SuperWASPFITSObservationSource extends ObservationSourcePluginBase 
 				if (hdu instanceof BinaryTableHDU) {
 					BinaryTableHDU tableHDU = (BinaryTableHDU) hdu;
 					
-					/*
-					System.out.println(tableHDU.getColumnName(0));
-					System.out.println(tableHDU.getColumnName(1));
-					System.out.println(tableHDU.getColumnName(2));
-					System.out.println(tableHDU.getColumnName(3));
-					System.out.println(tableHDU.getColumnName(4));
-					System.out.println(tableHDU.getColumnName(5));
-					System.out.println(tableHDU.getColumnName(6));
-					System.out.println(tableHDU.getColumnName(7));
-					*/
-					
 					int tableRows = tableHDU.getNRows();
 					for (int row = 0; row < tableRows && !wasInterrupted(); row++) {
 						try {


### PR DESCRIPTION
There are two versions of data in SuperWASP FITS file: FLUX2 and TAMFLUX2 (https://exoplanetarchive.ipac.caltech.edu/docs/SuperWASPProcessing.html). The situation is similar to TESS/Kepler: the first set is ‘raw’, the second one is ‘corrected’ (TAMFLUX2 = ‘SYSREM corrected fluxes’).

Existing SuperWASP plugin reads FLUX2 (‘raw’). The quality of the ‘raw’ data is too bad. On the other hand, magnitudes calculated from TAMFLUX2 (corrected fluxes) are the same as in CSV files that can be downloaded along with FITS from the SuperWASP portal (https://wasp.cerit-sc.cz/form).

I’ve been using SuperWASP CSV data for a long time and noticed quite long ago that they differ from those derived by VStar plugin from FITS. However, only now I investigated SuperWASP FITS and found the source of the discrepancy.

I’ve modified the SuperWASP plugin so that a user can choose a version of data. By default, the corrected (TAMFLUX2) version is selected.

I've also made the SuperWASP plugin 'heliocentric'
