### PR TITLE
FITS plugins(KeplerFITSObservationSource, LightKurveFITSObservationSo…

### DIFF
--- a/plugin/src/org/aavso/tools/vstar/external/plugin/KeplerFITSObservationSource.java
+++ b/plugin/src/org/aavso/tools/vstar/external/plugin/KeplerFITSObservationSource.java
@@ -200,8 +200,8 @@ public class KeplerFITSObservationSource extends ObservationSourcePluginBase {
 			// Kepler and TESS light curve FITS contains primary HDU having keywords only, binary table extension, and image extension (aperture).
 			if (hdus.length >  1 && hdus[0] instanceof ImageHDU && hdus[1] instanceof BinaryTableHDU) {
 
-				double minMagErr = Double.MAX_VALUE;
-				double maxMagErr = Double.MIN_VALUE;
+				//double minMagErr = Double.MAX_VALUE;
+				//double maxMagErr = Double.MIN_VALUE;
 
 				double invalidMag = 99.99;
 
@@ -237,9 +237,19 @@ public class KeplerFITSObservationSource extends ObservationSourcePluginBase {
 				objName = imageHDU.getObject();
 
 				BinaryTableHDU tableHDU = (BinaryTableHDU) hdus[1];
+				
+				// PMAK: Check field names to be sure we are using correct FITS.
+				if (!"TIME".equals(tableHDU.getColumnName(0)) ||
+					!"SAP_FLUX".equals(tableHDU.getColumnName(3)) ||
+					!"SAP_FLUX_ERR".equals(tableHDU.getColumnName(4)) ||
+					!"PDCSAP_FLUX".equals(tableHDU.getColumnName(7)) ||
+					!"PDCSAP_FLUX_ERR".equals(tableHDU.getColumnName(8))) {
+					throw new ObservationReadError("Not a valid FITS file");
+				}
+				
 				double timei = tableHDU.getHeader().getDoubleValue("BJDREFI");
 				double timef = tableHDU.getHeader().getDoubleValue("BJDREFF");
-				
+			
 				for (int row = 0; row < tableHDU.getNRows()	&& !wasInterrupted(); row++) {
 					try {
 						double barytime = ((double[]) tableHDU.getElement(row, 0))[0];
@@ -321,11 +331,11 @@ public class KeplerFITSObservationSource extends ObservationSourcePluginBase {
 					double mag = magShift - 2.5 * Math.log10(rawObs.intensity);
 					double magErr = 1.086 * rawObs.error / rawObs.intensity;
 					// PMAK: it seems minMagErr and maxMagErr not used?
-					if (magErr < minMagErr) {
-						minMagErr = magErr;
-					} else if (magErr > maxMagErr) {
-						maxMagErr = magErr;
-					}
+					//if (magErr < minMagErr) {
+					//	minMagErr = magErr;
+					//} else if (magErr > maxMagErr) {
+					//	maxMagErr = magErr;
+					//}
 
 					ValidObservation ob = new ValidObservation();
 					if (objName != null && !"".equals(objName.trim())) {

--- a/plugin/src/org/aavso/tools/vstar/external/plugin/LightKurveFITSObservationSource.java
+++ b/plugin/src/org/aavso/tools/vstar/external/plugin/LightKurveFITSObservationSource.java
@@ -140,7 +140,14 @@ public class LightKurveFITSObservationSource extends ObservationSourcePluginBase
 				SeriesType lightKurveSeries = dataSeriesLightKurve;
 				
 				BinaryTableHDU tableHDU = (BinaryTableHDU) hdus[1];
-				
+
+				// PMAK: Check field names to be sure we are using correct FITS.
+				if (!"TIME".equals(tableHDU.getColumnName(0)) ||
+					!"FLUX".equals(tableHDU.getColumnName(1)) ||
+					!"FLUX_ERR".equals(tableHDU.getColumnName(2))) {
+					throw new ObservationReadError("Not a valid FITS file");
+				}
+
 				double timeConstant = 0;
 				if ("TESS".equals(telescope)) {
 					lightKurveSeries = dataSeriesLightKurveTESS;


### PR DESCRIPTION
…urce, SuperWASPFITSObservationSource) check for binary table field names to be sure that the correct FITS is used.

Currently, we have 3 plugins that read FITS of different formats. Plug-ins reference data in the FITS binary table by column numbers (different for different formats). To avoid incorrect read, I inserted a piece of code in each plugin that checks for field names.
Issue #97 