### PR TITLE
#58: VeLa variables may undesirably change type

### DIFF
--- a/src/org/aavso/tools/vstar/vela/VeLaEnvironment.java
+++ b/src/org/aavso/tools/vstar/vela/VeLaEnvironment.java
@@ -67,6 +67,7 @@ public class VeLaEnvironment<T> {
 	 * @param name
 	 *            The name of the binding to lookup.
 	 * @return Whether the name is bound in this environment.
+	 * @deprecated less useful now, given the use of Optional values
 	 */
 	public boolean hasBinding(String name) {
 		return cache.containsKey(name);

--- a/src/org/aavso/tools/vstar/vela/VeLaInterpreter.java
+++ b/src/org/aavso/tools/vstar/vela/VeLaInterpreter.java
@@ -935,7 +935,7 @@ public class VeLaInterpreter {
 					bound = true;
 				} else {
 					throw new VeLaEvalError(
-							String.format("The type of the new value (%s) is not compatible with the bound type of %s.",
+							String.format("The type of the value (%s) is not compatible with the bound type of %s.",
 									value, name));
 				}
 				break;

--- a/test/org/aavso/tools/vstar/vela/VeLaTest.java
+++ b/test/org/aavso/tools/vstar/vela/VeLaTest.java
@@ -1074,11 +1074,9 @@ public class VeLaTest extends TestCase {
 	// Bindings
 
 	public void testBindingNonConstant() {
-		// Bind X to 42 then retrieve the bound value of X.
+		// Bind X to 2 then retrieve the bound value of X.
 		String prog = "";
 		prog += "x <- 12\n";
-		prog += "y <- x*x\n";
-		prog += "print(\"x squared is \" y \"\n\"\n)";
 		prog += "x";
 
 		Optional<Operand> result = vela.program(prog);
@@ -1090,6 +1088,22 @@ public class VeLaTest extends TestCase {
 		result = vela.program("x <- x + 1  x");
 		assertTrue(result.isPresent());
 		assertEquals(13, result.get().intVal());
+	}
+
+	public void testBindingNonConstantTwoTypes() {
+		// Bind X to 2
+		String prog = "x <- 2\n";
+
+		vela.program(prog);
+
+		// Attempt to bind X again but to a value of 
+		// type string, not integer. This should fail.
+		try {
+			vela.program("x <- \"2\"");
+			fail();
+		} catch (Exception e) {
+			// This is where we expect to be.
+		}
 	}
 
 	public void testBindingConstant1() {


### PR DESCRIPTION
Fixed by converting new value's type to the type of the existing binding or throwing an exception; added comments and deprecated a function.

