### PR TITLE
Issue 14 rcomma non en locales

### DIFF
--- a/plugin/src/org/aavso/tools/vstar/external/plugin/ApacheCommonsLoessFitter.java
+++ b/plugin/src/org/aavso/tools/vstar/external/plugin/ApacheCommonsLoessFitter.java
@@ -37,6 +37,7 @@ import org.aavso.tools.vstar.ui.model.plot.StandardPhaseCoordSource;
 import org.aavso.tools.vstar.util.locale.LocaleProps;
 import org.aavso.tools.vstar.util.model.IModel;
 import org.aavso.tools.vstar.util.model.PeriodFitParameters;
+import org.aavso.tools.vstar.util.prefs.NumericPrecisionPrefs;
 import org.apache.commons.math.MathException;
 import org.apache.commons.math.analysis.interpolation.LoessInterpolator;
 import org.apache.commons.math.analysis.polynomials.PolynomialFunction;
@@ -139,15 +140,16 @@ public class ApacheCommonsLoessFitter extends ModelCreatorPluginBase {
 
 						double constCoeff = 0;
 
+						// We use formatGeneral because of a huge range
 						for (PolynomialFunction f : function.getPolynomials()) {
 							double[] coeffs = f.getCoefficients();
 							for (int i = coeffs.length - 1; i >= 1; i--) {
-								strRepr += "    " + coeffs[i];
+								strRepr += "    " + NumericPrecisionPrefs.formatGeneral(coeffs[i]);
 								strRepr += "t^" + i + "+\n";
 							}
 							constCoeff += coeffs[0];
 						}
-						strRepr += "    " + constCoeff;
+						strRepr += "    " + NumericPrecisionPrefs.formatGeneral(constCoeff);
 						strRepr += "\n}";
 					}
 
@@ -163,16 +165,17 @@ public class ApacheCommonsLoessFitter extends ModelCreatorPluginBase {
 
 						double constCoeff = 0;
 
+						// We use formatGeneral because of a huge range
 						for (PolynomialFunction f : function.getPolynomials()) {
 							double[] coeffs = f.getCoefficients();
 							for (int i = coeffs.length - 1; i >= 1; i--) {
-								strRepr += coeffs[i];
-								strRepr += "*A1^" + i + ",\n";
+								strRepr += NumericPrecisionPrefs.formatGeneral(coeffs[i]);
+								strRepr += "*A1^" + i + NumericPrecisionPrefs.getExcelFormulaSeparator() + "\n";
 							}
 							constCoeff += coeffs[0];
 						}
 
-						strRepr += constCoeff + ")";
+						strRepr += NumericPrecisionPrefs.formatGeneral(constCoeff) + ")";
 					}
 
 					return strRepr;
@@ -181,25 +184,27 @@ public class ApacheCommonsLoessFitter extends ModelCreatorPluginBase {
 				// Note: There is already a Loess fit function in R, so it
 				// would be interesting to compare the results of that and this
 				// plugin.
+				// toRString must be locale-independent!
 				public String toRString() {
 					String strRepr = functionStrMap.get(LocaleProps
 							.get("MODEL_INFO_R_TITLE"));
 
 					if (strRepr == null) {
-						strRepr = "model <- function(t) ";
+						strRepr = "model <- function(t) \n";
 
 						double constCoeff = 0;
 
+						// We use formatGeneralLocaleIndependent because of a huge range
 						for (PolynomialFunction f : function.getPolynomials()) {
 							double[] coeffs = f.getCoefficients();
 							for (int i = coeffs.length - 1; i >= 1; i--) {
-								strRepr += coeffs[i];
+								strRepr += NumericPrecisionPrefs.formatGeneralLocaleIndependent(coeffs[i]);
 								strRepr += "*t^" + i + "+\n";
 							}
 							constCoeff += coeffs[0];
 						}
 
-						strRepr += constCoeff;
+						strRepr += NumericPrecisionPrefs.formatGeneralLocaleIndependent(constCoeff);
 					}
 
 					return strRepr;

--- a/plugin/src/org/aavso/tools/vstar/external/plugin/ApacheCommonsLoessFitter.java
+++ b/plugin/src/org/aavso/tools/vstar/external/plugin/ApacheCommonsLoessFitter.java
@@ -144,12 +144,12 @@ public class ApacheCommonsLoessFitter extends ModelCreatorPluginBase {
 						for (PolynomialFunction f : function.getPolynomials()) {
 							double[] coeffs = f.getCoefficients();
 							for (int i = coeffs.length - 1; i >= 1; i--) {
-								strRepr += "    " + NumericPrecisionPrefs.formatGeneral(coeffs[i]);
+								strRepr += "    " + NumericPrecisionPrefs.formatPolyCoef(coeffs[i]);
 								strRepr += "*t^" + i + "+\n";
 							}
 							constCoeff += coeffs[0];
 						}
-						strRepr += "    " + NumericPrecisionPrefs.formatGeneral(constCoeff);
+						strRepr += "    " + NumericPrecisionPrefs.formatPolyCoef(constCoeff);
 						strRepr += "\n}";
 					}
 
@@ -169,13 +169,13 @@ public class ApacheCommonsLoessFitter extends ModelCreatorPluginBase {
 						for (PolynomialFunction f : function.getPolynomials()) {
 							double[] coeffs = f.getCoefficients();
 							for (int i = coeffs.length - 1; i >= 1; i--) {
-								strRepr += NumericPrecisionPrefs.formatGeneral(coeffs[i]);
+								strRepr += NumericPrecisionPrefs.formatPolyCoef(coeffs[i]);
 								strRepr += "*A1^" + i + NumericPrecisionPrefs.getExcelFormulaSeparator() + "\n";
 							}
 							constCoeff += coeffs[0];
 						}
 
-						strRepr += NumericPrecisionPrefs.formatGeneral(constCoeff) + ")";
+						strRepr += NumericPrecisionPrefs.formatPolyCoef(constCoeff) + ")";
 					}
 
 					return strRepr;
@@ -198,13 +198,13 @@ public class ApacheCommonsLoessFitter extends ModelCreatorPluginBase {
 						for (PolynomialFunction f : function.getPolynomials()) {
 							double[] coeffs = f.getCoefficients();
 							for (int i = coeffs.length - 1; i >= 1; i--) {
-								strRepr += NumericPrecisionPrefs.formatGeneralLocaleIndependent(coeffs[i]);
+								strRepr += NumericPrecisionPrefs.formatPolyCoefLocaleIndependent(coeffs[i]);
 								strRepr += "*t^" + i + "+\n";
 							}
 							constCoeff += coeffs[0];
 						}
 
-						strRepr += NumericPrecisionPrefs.formatGeneralLocaleIndependent(constCoeff);
+						strRepr += NumericPrecisionPrefs.formatPolyCoefLocaleIndependent(constCoeff);
 					}
 
 					return strRepr;

--- a/plugin/src/org/aavso/tools/vstar/external/plugin/ApacheCommonsLoessFitter.java
+++ b/plugin/src/org/aavso/tools/vstar/external/plugin/ApacheCommonsLoessFitter.java
@@ -136,11 +136,11 @@ public class ApacheCommonsLoessFitter extends ModelCreatorPluginBase {
 							.get("MODEL_INFO_FUNCTION_TITLE"));
 
 					if (strRepr == null) {
+						/*
 						strRepr = "f(t:real) : real {\n";
 
 						double constCoeff = 0;
 
-						// We use formatGeneral because of a huge range
 						for (PolynomialFunction f : function.getPolynomials()) {
 							double[] coeffs = f.getCoefficients();
 							for (int i = coeffs.length - 1; i >= 1; i--) {
@@ -151,6 +151,8 @@ public class ApacheCommonsLoessFitter extends ModelCreatorPluginBase {
 						}
 						strRepr += "    " + NumericPrecisionPrefs.formatPolyCoef(constCoeff);
 						strRepr += "\n}";
+						*/
+						strRepr = Mediator.NOT_IMPLEMENTED_YET;
 					}
 
 					return strRepr;
@@ -161,11 +163,11 @@ public class ApacheCommonsLoessFitter extends ModelCreatorPluginBase {
 							.get("MODEL_INFO_EXCEL_TITLE"));
 
 					if (strRepr == null) {
+						/*
 						strRepr = "=SUM(";
 
 						double constCoeff = 0;
 
-						// We use formatGeneral because of a huge range
 						for (PolynomialFunction f : function.getPolynomials()) {
 							double[] coeffs = f.getCoefficients();
 							for (int i = coeffs.length - 1; i >= 1; i--) {
@@ -176,6 +178,8 @@ public class ApacheCommonsLoessFitter extends ModelCreatorPluginBase {
 						}
 
 						strRepr += NumericPrecisionPrefs.formatPolyCoef(constCoeff) + ")";
+						*/
+						strRepr = Mediator.NOT_IMPLEMENTED_YET;
 					}
 
 					return strRepr;
@@ -190,11 +194,11 @@ public class ApacheCommonsLoessFitter extends ModelCreatorPluginBase {
 							.get("MODEL_INFO_R_TITLE"));
 
 					if (strRepr == null) {
-						strRepr = "model <- function(t) \n";
+						/*
+						strRepr = "model <- function(t)\n";
 
 						double constCoeff = 0;
 
-						// We use formatGeneralLocaleIndependent because of a huge range
 						for (PolynomialFunction f : function.getPolynomials()) {
 							double[] coeffs = f.getCoefficients();
 							for (int i = coeffs.length - 1; i >= 1; i--) {
@@ -205,6 +209,8 @@ public class ApacheCommonsLoessFitter extends ModelCreatorPluginBase {
 						}
 
 						strRepr += NumericPrecisionPrefs.formatPolyCoefLocaleIndependent(constCoeff);
+						*/
+						strRepr = Mediator.NOT_IMPLEMENTED_YET;
 					}
 
 					return strRepr;

--- a/plugin/src/org/aavso/tools/vstar/external/plugin/ApacheCommonsLoessFitter.java
+++ b/plugin/src/org/aavso/tools/vstar/external/plugin/ApacheCommonsLoessFitter.java
@@ -145,7 +145,7 @@ public class ApacheCommonsLoessFitter extends ModelCreatorPluginBase {
 							double[] coeffs = f.getCoefficients();
 							for (int i = coeffs.length - 1; i >= 1; i--) {
 								strRepr += "    " + NumericPrecisionPrefs.formatGeneral(coeffs[i]);
-								strRepr += "t^" + i + "+\n";
+								strRepr += "*t^" + i + "+\n";
 							}
 							constCoeff += coeffs[0];
 						}

--- a/src/org/aavso/tools/vstar/plugin/model/impl/ApacheCommonsPolynomialFitCreatorPlugin.java
+++ b/src/org/aavso/tools/vstar/plugin/model/impl/ApacheCommonsPolynomialFitCreatorPlugin.java
@@ -254,12 +254,13 @@ public class ApacheCommonsPolynomialFitCreatorPlugin extends
 
 							strRepr += "f(t:real) : real {\n";
 
+							// We use formatGeneral because of a huge range
 							double[] coeffs = function.getCoefficients();
 							for (int i = coeffs.length - 1; i >= 1; i--) {
-								strRepr += "    " + coeffs[i];
+								strRepr += "    " + NumericPrecisionPrefs.formatGeneral(coeffs[i]);
 								strRepr += "*(t-zeroPoint)^" + i + " +\n";
 							}
-							strRepr += "    " + coeffs[0];
+							strRepr += "    " + NumericPrecisionPrefs.formatGeneral(coeffs[0]);
 							strRepr += "\n}";
 						}
 
@@ -273,20 +274,22 @@ public class ApacheCommonsPolynomialFitCreatorPlugin extends
 						if (strRepr == null) {
 							strRepr = "=SUM(";
 
+							// We use formatGeneral because of a huge range
 							double[] coeffs = function.getCoefficients();
 							for (int i = coeffs.length - 1; i >= 1; i--) {
-								strRepr += coeffs[i];
+								strRepr += NumericPrecisionPrefs.formatGeneral(coeffs[i]);
 								strRepr += "*(A1-"
 										+ NumericPrecisionPrefs
 												.formatTime(zeroPoint) + ")^"
-										+ i + ",\n";
+										+ i + NumericPrecisionPrefs.getExcelFormulaSeparator() + "\n";
 							}
-							strRepr += coeffs[0] + ")";
+							strRepr += NumericPrecisionPrefs.formatGeneral(coeffs[0]) + ")";
 						}
 
 						return strRepr;
 					}
 
+					// toRString must be locale-independent!
 					public String toRString() {
 						String strRepr = functionStrMap.get(LocaleProps
 								.get("MODEL_INFO_R_TITLE"));
@@ -294,16 +297,17 @@ public class ApacheCommonsPolynomialFitCreatorPlugin extends
 						if (strRepr == null) {
 							strRepr = "zeroPoint <- "
 									+ NumericPrecisionPrefs
-											.formatTime(zeroPoint) + "\n\n";
+											.formatTimeLocaleIndependent(zeroPoint) + "\n\n";
 
-							strRepr += "model <- function(t) ";
+							strRepr += "model <- function(t) \n";
 
+							// We use formatGeneralLocaleIndependent because of a huge range
 							double[] coeffs = function.getCoefficients();
 							for (int i = coeffs.length - 1; i >= 1; i--) {
-								strRepr += coeffs[i];
+								strRepr += NumericPrecisionPrefs.formatGeneralLocaleIndependent(coeffs[i]);
 								strRepr += "*(t-zeroPoint)^" + i + " +\n";
 							}
-							strRepr += coeffs[0];
+							strRepr += NumericPrecisionPrefs.formatGeneralLocaleIndependent(coeffs[0]);
 						}
 
 						return strRepr;

--- a/src/org/aavso/tools/vstar/plugin/model/impl/ApacheCommonsPolynomialFitCreatorPlugin.java
+++ b/src/org/aavso/tools/vstar/plugin/model/impl/ApacheCommonsPolynomialFitCreatorPlugin.java
@@ -257,10 +257,10 @@ public class ApacheCommonsPolynomialFitCreatorPlugin extends
 							// We use formatGeneral because of a huge range
 							double[] coeffs = function.getCoefficients();
 							for (int i = coeffs.length - 1; i >= 1; i--) {
-								strRepr += "    " + NumericPrecisionPrefs.formatGeneral(coeffs[i]);
+								strRepr += "    " + NumericPrecisionPrefs.formatPolyCoef(coeffs[i]);
 								strRepr += "*(t-zeroPoint)^" + i + " +\n";
 							}
-							strRepr += "    " + NumericPrecisionPrefs.formatGeneral(coeffs[0]);
+							strRepr += "    " + NumericPrecisionPrefs.formatPolyCoef(coeffs[0]);
 							strRepr += "\n}";
 						}
 
@@ -277,13 +277,13 @@ public class ApacheCommonsPolynomialFitCreatorPlugin extends
 							// We use formatGeneral because of a huge range
 							double[] coeffs = function.getCoefficients();
 							for (int i = coeffs.length - 1; i >= 1; i--) {
-								strRepr += NumericPrecisionPrefs.formatGeneral(coeffs[i]);
+								strRepr += NumericPrecisionPrefs.formatPolyCoef(coeffs[i]);
 								strRepr += "*(A1-"
 										+ NumericPrecisionPrefs
 												.formatTime(zeroPoint) + ")^"
 										+ i + NumericPrecisionPrefs.getExcelFormulaSeparator() + "\n";
 							}
-							strRepr += NumericPrecisionPrefs.formatGeneral(coeffs[0]) + ")";
+							strRepr += NumericPrecisionPrefs.formatPolyCoef(coeffs[0]) + ")";
 						}
 
 						return strRepr;
@@ -304,10 +304,10 @@ public class ApacheCommonsPolynomialFitCreatorPlugin extends
 							// We use formatGeneralLocaleIndependent because of a huge range
 							double[] coeffs = function.getCoefficients();
 							for (int i = coeffs.length - 1; i >= 1; i--) {
-								strRepr += NumericPrecisionPrefs.formatGeneralLocaleIndependent(coeffs[i]);
+								strRepr += NumericPrecisionPrefs.formatPolyCoefLocaleIndependent(coeffs[i]);
 								strRepr += "*(t-zeroPoint)^" + i + " +\n";
 							}
-							strRepr += NumericPrecisionPrefs.formatGeneralLocaleIndependent(coeffs[0]);
+							strRepr += NumericPrecisionPrefs.formatPolyCoefLocaleIndependent(coeffs[0]);
 						}
 
 						return strRepr;

--- a/src/org/aavso/tools/vstar/plugin/model/impl/ApacheCommonsPolynomialFitCreatorPlugin.java
+++ b/src/org/aavso/tools/vstar/plugin/model/impl/ApacheCommonsPolynomialFitCreatorPlugin.java
@@ -254,7 +254,6 @@ public class ApacheCommonsPolynomialFitCreatorPlugin extends
 
 							strRepr += "f(t:real) : real {\n";
 
-							// We use formatGeneral because of a huge range
 							double[] coeffs = function.getCoefficients();
 							for (int i = coeffs.length - 1; i >= 1; i--) {
 								strRepr += "    " + NumericPrecisionPrefs.formatPolyCoef(coeffs[i]);
@@ -272,18 +271,17 @@ public class ApacheCommonsPolynomialFitCreatorPlugin extends
 								.get("MODEL_INFO_EXCEL_TITLE"));
 
 						if (strRepr == null) {
-							strRepr = "=SUM(";
+							strRepr = "=";
 
-							// We use formatGeneral because of a huge range
 							double[] coeffs = function.getCoefficients();
 							for (int i = coeffs.length - 1; i >= 1; i--) {
 								strRepr += NumericPrecisionPrefs.formatPolyCoef(coeffs[i]);
 								strRepr += "*(A1-"
 										+ NumericPrecisionPrefs
 												.formatTime(zeroPoint) + ")^"
-										+ i + NumericPrecisionPrefs.getExcelFormulaSeparator() + "\n";
+										+ i + "+\n";
 							}
-							strRepr += NumericPrecisionPrefs.formatPolyCoef(coeffs[0]) + ")";
+							strRepr += NumericPrecisionPrefs.formatPolyCoef(coeffs[0]);
 						}
 
 						return strRepr;
@@ -299,9 +297,8 @@ public class ApacheCommonsPolynomialFitCreatorPlugin extends
 									+ NumericPrecisionPrefs
 											.formatTimeLocaleIndependent(zeroPoint) + "\n\n";
 
-							strRepr += "model <- function(t) \n";
+							strRepr += "model <- function(t)\n";
 
-							// We use formatGeneralLocaleIndependent because of a huge range
 							double[] coeffs = function.getCoefficients();
 							for (int i = coeffs.length - 1; i >= 1; i--) {
 								strRepr += NumericPrecisionPrefs.formatPolyCoefLocaleIndependent(coeffs[i]);

--- a/src/org/aavso/tools/vstar/util/locale/LocaleProps.java
+++ b/src/org/aavso/tools/vstar/util/locale/LocaleProps.java
@@ -21,6 +21,8 @@ import java.util.Locale;
 import java.util.ResourceBundle;
 import java.util.prefs.Preferences;
 
+import org.aavso.tools.vstar.util.prefs.NumericPrecisionPrefs;
+
 /**
  * The purpose of this class is to provide locale-specific strings and
  * preference handling.
@@ -64,6 +66,9 @@ public class LocaleProps {
 		} catch (Throwable t) {
 			// We need VStar to function in the absence of prefs.
 		}
+		
+		// PMAK: to avoid using cashed formats after locale change   
+		NumericPrecisionPrefs.clearHashMaps();
 	}
 
 	public static void setDefaultLocalePref() {

--- a/src/org/aavso/tools/vstar/util/model/PeriodAnalysisDerivedMultiPeriodicModel.java
+++ b/src/org/aavso/tools/vstar/util/model/PeriodAnalysisDerivedMultiPeriodicModel.java
@@ -208,6 +208,7 @@ public class PeriodAnalysisDerivedMultiPeriodicModel implements IModel {
 		return strRepr;
 	}
 
+	// toRString must be locale-independent!
 	private String toRString() {
 		String strRepr = functionStrMap.get(LocaleProps
 				.get("MODEL_INFO_R_TITLE"));
@@ -217,14 +218,14 @@ public class PeriodAnalysisDerivedMultiPeriodicModel implements IModel {
 			// created; the zero point will be the same for all parameters, so
 			// just get it from the first.
 			strRepr = "zeroPoint <- "
-					+ NumericPrecisionPrefs.formatTime(parameters.get(0)
+					+ NumericPrecisionPrefs.formatTimeLocaleIndependent(parameters.get(0)
 							.getZeroPointOffset()) + "\n\n";
 
 			strRepr += "model <- function(t) ";
 
 			double constantCoefficient = parameters.get(0)
 					.getConstantCoefficient();
-			strRepr += NumericPrecisionPrefs.formatOther(constantCoefficient);
+			strRepr += NumericPrecisionPrefs.formatOtherLocaleIndependent(constantCoefficient);
 
 			for (int i = 0; i < parameters.size(); i++) {
 				PeriodFitParameters params = parameters.get(i);

--- a/src/org/aavso/tools/vstar/util/model/PeriodAnalysisDerivedMultiPeriodicModel.java
+++ b/src/org/aavso/tools/vstar/util/model/PeriodAnalysisDerivedMultiPeriodicModel.java
@@ -191,18 +191,18 @@ public class PeriodAnalysisDerivedMultiPeriodicModel implements IModel {
 				.get("MODEL_INFO_EXCEL_TITLE"));
 
 		if (strRepr == null) {
-			strRepr = "=SUM(";
+			strRepr = "=";
 
 			double constantCoefficient = parameters.get(0)
 					.getConstantCoefficient();
-			strRepr += NumericPrecisionPrefs.formatOther(constantCoefficient);
+			strRepr += NumericPrecisionPrefs.formatOther(constantCoefficient)
+					+ "\n";
 
 			for (int i = 0; i < parameters.size(); i++) {
 				PeriodFitParameters params = parameters.get(i);
-				strRepr += params.toExcelString();
+				strRepr += params.toExcelString() + "\n";
 			}
 
-			strRepr += ")";
 		}
 
 		return strRepr;
@@ -221,7 +221,7 @@ public class PeriodAnalysisDerivedMultiPeriodicModel implements IModel {
 					+ NumericPrecisionPrefs.formatTimeLocaleIndependent(parameters.get(0)
 							.getZeroPointOffset()) + "\n\n";
 
-			strRepr += "model <- function(t) ";
+			strRepr += "model <- function(t)\n";
 
 			double constantCoefficient = parameters.get(0)
 					.getConstantCoefficient();

--- a/src/org/aavso/tools/vstar/util/model/PeriodFitParameters.java
+++ b/src/org/aavso/tools/vstar/util/model/PeriodFitParameters.java
@@ -275,20 +275,20 @@ public class PeriodFitParameters implements Comparable<PeriodFitParameters> {
 	}
 
 	public String toExcelString() {
-		String str = null;
-
-		str = cosineCoefficient != 0 ? NumericPrecisionPrefs.getExcelFormulaSeparator() + "\n" : "\n";
+		String str = cosineCoefficient >= 0 ? "+" : "";
 
 		String sincosParam = "2*PI()*" + harmonic + "*(A1-"
 				+ NumericPrecisionPrefs.formatTime(zeroPointOffset) + ")";
 
-		str += NumericPrecisionPrefs.formatOther(cosineCoefficient) + " * COS(";
+		str += NumericPrecisionPrefs.formatOther(cosineCoefficient) 
+				+ " * COS(";
 		str += sincosParam;
 		str += ")";
 
-		str += sineCoefficient != 0 ? NumericPrecisionPrefs.getExcelFormulaSeparator() + "\n" : "\n";
+		str += sineCoefficient >= 0 ? " + " : "";
 
-		str += NumericPrecisionPrefs.formatOther(sineCoefficient) + " * SIN(";
+		str += NumericPrecisionPrefs.formatOther(sineCoefficient) 
+				+ " * SIN(";
 		str += sincosParam;
 		str += ")";
 

--- a/src/org/aavso/tools/vstar/util/model/PeriodFitParameters.java
+++ b/src/org/aavso/tools/vstar/util/model/PeriodFitParameters.java
@@ -277,7 +277,7 @@ public class PeriodFitParameters implements Comparable<PeriodFitParameters> {
 	public String toExcelString() {
 		String str = null;
 
-		str = cosineCoefficient != 0 ? ",\n" : "\n";
+		str = cosineCoefficient != 0 ? NumericPrecisionPrefs.getExcelFormulaSeparator() + "\n" : "\n";
 
 		String sincosParam = "2*PI()*" + harmonic + "*(A1-"
 				+ NumericPrecisionPrefs.formatTime(zeroPointOffset) + ")";
@@ -286,7 +286,7 @@ public class PeriodFitParameters implements Comparable<PeriodFitParameters> {
 		str += sincosParam;
 		str += ")";
 
-		str += sineCoefficient != 0 ? ",\n" : "\n";
+		str += sineCoefficient != 0 ? NumericPrecisionPrefs.getExcelFormulaSeparator() + "\n" : "\n";
 
 		str += NumericPrecisionPrefs.formatOther(sineCoefficient) + " * SIN(";
 		str += sincosParam;
@@ -295,18 +295,20 @@ public class PeriodFitParameters implements Comparable<PeriodFitParameters> {
 		return str;
 	}
 
+	// toRString must be locale-independent!
 	public String toRString() {
 		String str = "+\n";
 
-		String sincosParam = "2*pi*" + harmonic + "*(t-zeroPoint" + ")";
+		// harmonic.toString() is locale-dependent!
+		String sincosParam = "2*pi*" + NumericPrecisionPrefs.formatOtherLocaleIndependent(harmonic.getFrequency()) + "*(t-zeroPoint" + ")";
 
-		str += NumericPrecisionPrefs.formatOther(cosineCoefficient) + " * cos(";
+		str += NumericPrecisionPrefs.formatOtherLocaleIndependent(cosineCoefficient) + " * cos(";
 		str += sincosParam;
 		str += ")";
 
 		str += sineCoefficient >= 0 ? " + " : "";
 
-		str += NumericPrecisionPrefs.formatOther(sineCoefficient) + " * sin(";
+		str += NumericPrecisionPrefs.formatOtherLocaleIndependent(sineCoefficient) + " * sin(";
 		str += sincosParam;
 		str += ")";
 

--- a/src/org/aavso/tools/vstar/util/prefs/NumericPrecisionPrefs.java
+++ b/src/org/aavso/tools/vstar/util/prefs/NumericPrecisionPrefs.java
@@ -84,10 +84,12 @@ public class NumericPrecisionPrefs {
 	// locale-sensitive parameter). So we make an assumption. 
 	private static char excelFormulaSeparator;
 	
+	private static char decimalSeparator;
+	
 	static {
 		DecimalFormat format = (DecimalFormat) DecimalFormat.getInstance();
 		DecimalFormatSymbols symbols = format.getDecimalFormatSymbols();
-		char decimalSeparator = symbols.getDecimalSeparator();
+		decimalSeparator = symbols.getDecimalSeparator();
 		excelFormulaSeparator = decimalSeparator != ',' ? ',' : ';';
 	}
 
@@ -205,11 +207,26 @@ public class NumericPrecisionPrefs {
 	// General format
 	
 	public static String formatGeneral(double num) {
-		return String.format("%." + otherDecimalPlaces + "g", num);
+		String s = String.format("%." + otherDecimalPlaces + "G", num);
+		// VeLa parser problems workaround
+		if (s.indexOf("E") != -1) {
+			s = s.replace("E+", "E");
+		} else if (s.indexOf(decimalSeparator) == -1)
+			// only if no exponent!
+			s += decimalSeparator + "0";
+		return s;
 	}
 	
 	public static String formatGeneralLocaleIndependent(double num) {
-		return String.format(Locale.ENGLISH, "%." + otherDecimalPlaces + "g", num);
+		String s = String.format(Locale.ENGLISH, "%." + otherDecimalPlaces + "G", num);
+		// VeLa parser problems workaround
+		if (s.indexOf("E") != -1) {
+			s = s.replace("E+", "E");
+		} else 	if (s.indexOf('.') == -1) {
+			// only if no exponent!
+			s += ".0";
+		}
+		return s;
 	}
 	
 	// Excel formula separator

--- a/src/org/aavso/tools/vstar/util/prefs/NumericPrecisionPrefs.java
+++ b/src/org/aavso/tools/vstar/util/prefs/NumericPrecisionPrefs.java
@@ -61,6 +61,12 @@ public class NumericPrecisionPrefs {
 	private static Map<Integer, DecimalFormat> magOutputFormats = new HashMap<Integer, DecimalFormat>();
 	private static Map<Integer, DecimalFormat> otherOutputFormats = new HashMap<Integer, DecimalFormat>();
 
+	// Output decimal place maps: locale-independent formats.
+	
+	private static Map<Integer, DecimalFormat> timeOutputFormatsLocaleIndependent = new HashMap<Integer, DecimalFormat>();
+	private static Map<Integer, DecimalFormat> magOutputFormatsLocaleIndependent = new HashMap<Integer, DecimalFormat>();
+	private static Map<Integer, DecimalFormat> otherOutputFormatsLocaleIndependent = new HashMap<Integer, DecimalFormat>();
+		
 	// Default decimal place values.
 
 	private static int DEFAULT_TIME_DECIMAL_PLACES = 5;
@@ -72,6 +78,18 @@ public class NumericPrecisionPrefs {
 	private static int timeDecimalPlaces = DEFAULT_TIME_DECIMAL_PLACES;
 	private static int magDecimalPlaces = DEFAULT_MAG_DECIMAL_PLACES;
 	private static int otherDecimalPlaces = DEFAULT_OTHER_DECIMAL_PLACES;
+	
+	// List separator (for EXCEL formula)
+	// There is no way to get system "list separator" (Windows specific
+	// locale-sensitive parameter). So we make an assumption. 
+	private static char excelFormulaSeparator;
+	
+	static {
+		DecimalFormat format = (DecimalFormat) DecimalFormat.getInstance();
+		DecimalFormatSymbols symbols = format.getDecimalFormatSymbols();
+		char decimalSeparator = symbols.getDecimalSeparator();
+		excelFormulaSeparator = decimalSeparator != ',' ? ',' : ';';
+	}
 
 	/**
 	 * @return the timeDecimalPlaces
@@ -127,6 +145,14 @@ public class NumericPrecisionPrefs {
 	public static DecimalFormat getTimeOutputFormat() {
 		return getOutputFormat(timeDecimalPlaces, Type.TIME);
 	}
+	
+	public static String formatTimeLocaleIndependent(double num) {
+		return getTimeOutputFormatLocaleIndependent().format(num);
+	}
+	
+	public static DecimalFormat getTimeOutputFormatLocaleIndependent() {
+		return getOutputFormatLocaleIndependent(timeDecimalPlaces, Type.TIME);
+	}
 
 	public static String getTimeInputFormat() {
 		return getInputFormatString(timeDecimalPlaces, Type.TIME);
@@ -140,6 +166,14 @@ public class NumericPrecisionPrefs {
 
 	public static DecimalFormat getMagOutputFormat() {
 		return getOutputFormat(magDecimalPlaces, Type.MAG);
+	}
+	
+	public static String formatMagLocaleIndependent(double num) {
+		return getMagOutputFormatLocaleIndependent().format(num);
+	}
+	
+	public static DecimalFormat getMagOutputFormatLocaleIndependent() {
+		return getOutputFormatLocaleIndependent(magDecimalPlaces, Type.MAG);
 	}
 
 	public static String getMagInputFormat() {
@@ -156,10 +190,33 @@ public class NumericPrecisionPrefs {
 		return getOutputFormat(otherDecimalPlaces, Type.OTHER);
 	}
 
+	public static String formatOtherLocaleIndependent(double num) {
+		return getOtherOutputFormatLocaleIndependent().format(num);
+	}
+	
+	public static DecimalFormat getOtherOutputFormatLocaleIndependent() {
+		return getOutputFormatLocaleIndependent(otherDecimalPlaces, Type.OTHER);
+	}
+	
 	public static String getOtherInputFormat() {
 		return getInputFormatString(otherDecimalPlaces, Type.OTHER);
 	}
 
+	// General format
+	
+	public static String formatGeneral(double num) {
+		return String.format("%." + otherDecimalPlaces + "g", num);
+	}
+	
+	public static String formatGeneralLocaleIndependent(double num) {
+		return String.format(Locale.ENGLISH, "%." + otherDecimalPlaces + "g", num);
+	}
+	
+	// Excel formula separator
+	public static char getExcelFormulaSeparator() {
+		return excelFormulaSeparator;
+	}
+	
 	// Helpers
 
 	// Construct a formatter for numeric output.
@@ -184,7 +241,30 @@ public class NumericPrecisionPrefs {
 
 		return formats.get(decimalPlaces);
 	}
+	
+	// Construct a formatter for locale-independent numeric output.
+	private static DecimalFormat getOutputFormatLocaleIndependent(int decimalPlaces, Type type) {
+		Map<Integer, DecimalFormat> formats = null;
 
+		switch (type) {
+		case MAG:
+			formats = magOutputFormatsLocaleIndependent;
+			break;
+		case TIME:
+			formats = timeOutputFormatsLocaleIndependent;
+			break;
+		case OTHER:
+			formats = otherOutputFormatsLocaleIndependent;
+			break;
+		}
+
+		if (!formats.containsKey(decimalPlaces)) {
+			formats.put(decimalPlaces, getOutputFormatLocaleIndependent(decimalPlaces));
+		}
+
+		return formats.get(decimalPlaces);
+	}
+	
 	// Construct a format string of the form #.##... where the ellipsis
 	// denotes a variable number of hashes. This can be used with input text
 	// boxes where a numeric input is required.
@@ -214,6 +294,14 @@ public class NumericPrecisionPrefs {
 		DecimalFormat decFormatter = new DecimalFormat(
 				getFormatString(decimalPlaces), new DecimalFormatSymbols(Locale
 						.getDefault()));
+
+		return decFormatter;
+	}
+	
+	private static DecimalFormat getOutputFormatLocaleIndependent(int decimalPlaces) {
+		DecimalFormat decFormatter = new DecimalFormat(
+				getFormatString(decimalPlaces), new DecimalFormatSymbols(Locale
+						.ENGLISH));
 
 		return decFormatter;
 	}

--- a/src/org/aavso/tools/vstar/util/prefs/NumericPrecisionPrefs.java
+++ b/src/org/aavso/tools/vstar/util/prefs/NumericPrecisionPrefs.java
@@ -213,12 +213,10 @@ public class NumericPrecisionPrefs {
 	// PolyCoefFormat
 	
 	public static String formatPolyCoef(double num) {
-		//return formatGeneral(num);
 		return formatScientific(num);
 	}
 
 	public static String formatPolyCoefLocaleIndependent(double num) {
-		//return formatGeneralLocaleIndependent(num);
 		return formatScientificLocaleIndependent(num);
 	}
 	
@@ -234,48 +232,6 @@ public class NumericPrecisionPrefs {
 		return String.format(Locale.ENGLISH, "%." + otherDecimalPlaces + "E", num).replace("E+", "E");
 	}
 
-/*	
-	// General format
-	
-	private static String formatGeneral(double num) {
-		String s = String.format(Locale.getDefault(), "%." + otherDecimalPlaces + "G", num);
-		// VeLa parser problems workaround
-		if (s.indexOf("E") != -1) {
-			s = s.replace("E+", "E");
-		} else if (s.indexOf(decimalSeparator) == -1)
-			// only if no exponent!
-			s += decimalSeparator + "0";
-		return s;
-	}
-	
-	private static String formatGeneralLocaleIndependent(double num) {
-		String s = String.format(Locale.ENGLISH, "%." + otherDecimalPlaces + "G", num);
-		// VeLa parser problems workaround
-		if (s.indexOf("E") != -1) {
-			s = s.replace("E+", "E");
-		} else 	if (s.indexOf('.') == -1) {
-			// only if no exponent!
-			s += ".0";
-		}
-		return s;
-	}
-*/	
-	
-	// Excel formula separator (list separator)
-	// There is no way to get system "list separator" (Windows specific
-	// locale-sensitive parameter). So we make an assumption. 
-	// Why not replace SUM() in Excel formulas with a simple a+b+c... expression?
-	// We could get rid of the list separator at all!
-	public static char getExcelFormulaSeparator() {
-		return getDecimalSeparator() != ',' ? ',' : ';';
-	}
-	
-	private static char getDecimalSeparator() {
-		return getOtherOutputFormat()
-				.getDecimalFormatSymbols()
-					.getDecimalSeparator();
-	}
-	
 	// Helpers
 
 	// Construct a formatter for numeric output.


### PR DESCRIPTION
Hi David @dbenn,

This branch addresses issues #14 and #92.
The following files/classes have been changed:
ApacheCommonsLoessFitter.java
ApacheCommonsPolynomialFitCreatorPlugin.java
PeriodAnalysisDerivedMultiPeriodicModel.java
PeriodFitParameters.java

toRString(): locale-independent formatting (using ENGLISH locale)
toExcelString(): formula separator should be locale-dependent. If ',' is a decimal separator, the Excel formula separator is changed to ';'.

ApacheCommonsLoessFitter, ApacheCommonsPolynomialFitCreatorPlugin: polynomial coefficients are formatted now using scientific notation (with configured precision: in this case it is a total number of significant digits) via new functions NumericPrecisionPrefs.formatPolyCoef/formatPolyCoefLocaleIndependent. This is because the coefficients could have a huge range and must be formatted with exponential notation (at least in some cases).

Before the fix, polynomial coefficients were converted to strings implicitly (with implicit Double.toString() call), so they did not respect locale at all.

Excel formula issue (locale-dependent list separator) arose because the Excel formulas are implemented with SUM() function. We cannot use ',' when the decimal separator is also a comma (in my locale with ',' as a decimal separator, the default list separator is ';'). Why not get rid of SUM(a, b, c ...)? The formula could be in the form a + b + c +..., like other ones. What do you think?

Apparently, there is also a problem with functions for models generated by Loess plug-in. First, they are too long. And it seems they are incorrect. Maybe I'm doing something wrong, yet I cannot regenerate the model with those functions...


Concerning #138: formatPolyCoef returns string representation of a number in scientific notation with E+replaced by E as a workaround.