### PR TITLE
#140: using common valflags for simple and AAVSO download formats and added unvalidated valflag

### DIFF
--- a/src/org/aavso/tools/vstar/data/ValidationType.java
+++ b/src/org/aavso/tools/vstar/data/ValidationType.java
@@ -35,6 +35,7 @@ public enum ValidationType {
 	GOOD,
 	DISCREPANT,
 	PREVALIDATION,
+	UNVALIDATED,
 	BAD;	
 		
 	/**
@@ -50,6 +51,8 @@ public enum ValidationType {
 			valtype = DISCREPANT;
 		} else if ("P".equals(valflag)) {
 			valtype = GOOD;
+		} else if ("U".equals(valflag)) {
+			valtype = UNVALIDATED;
 		} else if ("V".equals(valflag)) {
 			valtype = GOOD;
 		} else if ("Z".equals(valflag)) {
@@ -79,7 +82,10 @@ public enum ValidationType {
 			// this for saving files, this seems reasonable.
 		case PREVALIDATION:
 			str = "P";
-			break;			
+			break;
+		case UNVALIDATED:
+			str = "U";
+			break;
 		case BAD:
 			str = "B";
 			break;
@@ -105,7 +111,10 @@ public enum ValidationType {
 			break;			
 		case PREVALIDATION:
 			str = "Prevalidated";
-			break;			
+			break;
+		case UNVALIDATED:
+			str = "Unvalidated";
+			break;
 		case BAD:
 			str = "Bad";
 			break;

--- a/src/org/aavso/tools/vstar/data/validation/AAVSODownloadFormatValidator.java
+++ b/src/org/aavso/tools/vstar/data/validation/AAVSODownloadFormatValidator.java
@@ -77,7 +77,7 @@ public class AAVSODownloadFormatValidator extends CommonTextFormatValidator {
 	public AAVSODownloadFormatValidator(CsvReader lineReader, int minFields,
 			int maxFields, IFieldInfoSource fieldInfoSource) throws IOException {
 		super("AAVSO format observation line", lineReader, minFields,
-				maxFields, "G|D|T|P|V|Z", fieldInfoSource);
+				maxFields, COMMON_VALFLAG_PATTERN, fieldInfoSource);
 
 		this.optionalFieldValidator = new OptionalityFieldValidator(
 				OptionalityFieldValidator.CAN_BE_EMPTY);

--- a/src/org/aavso/tools/vstar/data/validation/CommonTextFormatValidator.java
+++ b/src/org/aavso/tools/vstar/data/validation/CommonTextFormatValidator.java
@@ -34,12 +34,13 @@ import com.csvreader.CsvReader;
  * This class accepts a line of text for tokenising, validation, and
  * ValidObservation instance creation that is common to all text format sources.
  * Currently, simple and AAVSO download file formats have an intersecting set of
- * mandatory and optional fields. The field indices differ across formats, as
- * does what counts as a legal valflag field value, but the fieldIndexMap and
- * valflagPatternStr constructor arguments cater for the differences.
+ * mandatory and optional fields. The field indices differ across formats but the 
+ * fieldIndexMap constructor argument caters for the differences.
  */
 public class CommonTextFormatValidator {
 
+	protected final static String COMMON_VALFLAG_PATTERN = "G|D|T|P|V|Z";
+	
 	protected final ObservationFieldSplitter fieldSplitter;
 
 	protected CsvReader lineReader;
@@ -68,8 +69,7 @@ public class CommonTextFormatValidator {
 	 *            The maximum number of fields permitted in an observation line.
 	 * @param valflagPatternStr
 	 *            A regex pattern representing the alternations of permitted
-	 *            valflags for this validator instance, e.g. "D" (simple format)
-	 *            or "G|D|T|P|V|Z" (AAVSO download format).
+	 *            valflags for this validator instance, e.g. COMMON_VALFLAG_PATTERN
 	 * @param fieldInfoSource
 	 *            A mapping from field name to field index that makes sense for
 	 *            the source.

--- a/src/org/aavso/tools/vstar/data/validation/CommonTextFormatValidator.java
+++ b/src/org/aavso/tools/vstar/data/validation/CommonTextFormatValidator.java
@@ -39,7 +39,7 @@ import com.csvreader.CsvReader;
  */
 public class CommonTextFormatValidator {
 
-	protected final static String COMMON_VALFLAG_PATTERN = "G|D|T|P|V|Z";
+	protected final static String COMMON_VALFLAG_PATTERN = "G|D|T|P|U|V|Z";
 	
 	protected final ObservationFieldSplitter fieldSplitter;
 

--- a/src/org/aavso/tools/vstar/data/validation/SimpleTextFormatValidator.java
+++ b/src/org/aavso/tools/vstar/data/validation/SimpleTextFormatValidator.java
@@ -52,7 +52,7 @@ public class SimpleTextFormatValidator extends CommonTextFormatValidator {
 	public SimpleTextFormatValidator(CsvReader lineReader, int minFields,
 			int maxFields, IFieldInfoSource fieldInfoSource) throws IOException {
 		super("simple text format observation line", lineReader, minFields,
-				maxFields, "D", fieldInfoSource);
+				maxFields, COMMON_VALFLAG_PATTERN, fieldInfoSource);
 	}
 
 	/**

--- a/src/org/aavso/tools/vstar/data/validation/ValflagValidator.java
+++ b/src/org/aavso/tools/vstar/data/validation/ValflagValidator.java
@@ -36,10 +36,10 @@ public class ValflagValidator extends AbstractStringValidator<ValidationType> {
 	 * 
 	 * @param valflagPatternStr
 	 *            A regex pattern representing the alternations of permission
-	 *            valflags for this validator instance, e.g. "D" (simple format)
-	 *            or "G|D|T|P|V|Z" (AAVSO download format). This pattern string
-	 *            will be wrapped in a ^(...)$ to ensure that nothing else
-	 *            exists in the string, and that there is one capturing group.
+	 *            valflags for this validator instance, e.g. "G|D|T|P|V|Z"
+	 *            (AAVSO download format). This pattern string will be wrapped
+	 *            in a ^(...)$ to ensure that nothing else exists in the string,
+	 *            and that there is one capturing group.
 	 */
 	public ValflagValidator(String valflagPatternStr) {
 		super(KIND);

--- a/test/org/aavso/tools/vstar/input/text/TextFormatObservationReaderTest.java
+++ b/test/org/aavso/tools/vstar/input/text/TextFormatObservationReaderTest.java
@@ -26,6 +26,7 @@ import junit.framework.TestCase;
 
 import org.aavso.tools.vstar.data.SeriesType;
 import org.aavso.tools.vstar.data.ValidObservation;
+import org.aavso.tools.vstar.data.ValidationType;
 import org.aavso.tools.vstar.data.validation.SimpleTextFormatValidator;
 import org.aavso.tools.vstar.exception.ObservationValidationError;
 import org.aavso.tools.vstar.exception.ObservationValidationWarning;
@@ -62,12 +63,21 @@ public class TextFormatObservationReaderTest extends TestCase {
 		commonValidJulianDayAndMagTest("2450001.5,10.0\n", ",");
 	}
 
-	public void testSimpleValidFullObservationTSV() {
+	public void testSimpleValidFullObservationValflagDiscrepantTSV() {
 		ValidObservation ob = commonValidJulianDayAndMagTest(
 				"2450001.5\t10.0\t0.1\tDJB\tD\n", "\t");
 		assertEquals(0.1, ob.getMagnitude().getUncertainty());
 		assertEquals("DJB", ob.getObsCode());
+		assertEquals(ValidationType.DISCREPANT, ob.getValidationType());
 		assertTrue(ob.isDiscrepant());
+	}
+
+	public void testSimpleValidFullObservationValflagUnvalidatedTSV() {
+		ValidObservation ob = commonValidJulianDayAndMagTest(
+				"2450001.5\t10.0\t0.1\tDJB\tU\n", "\t");
+		assertEquals(0.1, ob.getMagnitude().getUncertainty());
+		assertEquals("DJB", ob.getObsCode());
+		assertEquals(ValidationType.UNVALIDATED, ob.getValidationType());
 	}
 
 	public void testSimpleValidAllButUncertaintyTSV() {


### PR DESCRIPTION
This gives backward compatibilty with simple format (that permitted the D valflag) and unifies both formats with respect to valflags.