### PR TITLE
Updating plot and table after HJD convert: Issue #76

### DIFF
--- a/plugin/src/org/aavso/tools/vstar/external/plugin/HJDConverter.java
+++ b/plugin/src/org/aavso/tools/vstar/external/plugin/HJDConverter.java
@@ -17,8 +17,6 @@
  */
 package org.aavso.tools.vstar.external.plugin;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -215,37 +213,18 @@ public class HJDConverter extends ObservationToolPluginBase {
 		// PMAK (2021-06-03):
 		// There is no way to recalculate observation phases (as for VStar 2.21.3)
 		// So we are switching to RAW plot and trying to delete existing phase plot.
-		// Again, there was no method to do it (VStar 2.21.3).
-		// We are checking if the new 'Mediator.dropPhasePlotAnalysis' method exists
-		// (to make the plug-in compatible with the previous VStar build)
-		// and invoking it if possible.
 		
 		Mediator mediator = Mediator.getInstance();
 		
 		mediator.changeAnalysisType(AnalysisType.RAW_DATA);
 
-		boolean phasePlotDeleted = false;
-		Method dropPhasePlotAnalysis = null;
 		try {
-			dropPhasePlotAnalysis = Mediator.class.getMethod("dropPhasePlotAnalysis", (Class<?>[]) null);
-		} catch (NoSuchMethodException | SecurityException e) {
-		  // do nothing
-		}
-		if (dropPhasePlotAnalysis != null) {
-			try {
-				dropPhasePlotAnalysis.invoke(mediator, (Object[]) null);
-				phasePlotDeleted =  true;
-			} catch (InvocationTargetException | IllegalAccessException e) {
-				// do nothing
-			}
-		}
-		
-		if (!phasePlotDeleted) {
-			// Warn the user if the current phase plot cannot be deleted...
+			mediator.dropPhasePlotAnalysis();
+		} catch (Exception e) {
 			MessageBox.showWarningDialog("HJD Conversion", 
-					"Please recreate Phase Plot to reflect changes.");
+				"Cannot delete current Phase Plot. Please recreate it to reflect changes.");
 		}
-		
+	
 		// Updates RAW plot and data table.
 		Mediator.getInstance().updatePlotsAndTables();
 		

--- a/src/org/aavso/tools/vstar/ui/mediator/Mediator.java
+++ b/src/org/aavso/tools/vstar/ui/mediator/Mediator.java
@@ -689,6 +689,16 @@ public class Mediator {
 		};
 	}
 
+	
+	/**
+	 * Removes phase plot if exists.
+	 * 
+	 */
+	public void dropPhasePlotAnalysis() {
+		assert(analysisType != AnalysisType.PHASE_PLOT);
+		analysisTypeMap.remove(AnalysisType.PHASE_PLOT);
+	}
+	
 	/**
 	 * Create a phase plot, first asking for period and epoch.
 	 * 


### PR DESCRIPTION
Issue #76 fix.
In HJDConverter: updateUI() method. It switches to raw plot and tries to delete phase plot if active (because phases cannot be updated in the current VStar version), refreshes the table pane, and raw plot. A new "dropPhasePlotAnalysis()" method added to Mediator.