### PR TITLE
Issue 208 extend jd to cal date plugin

### DIFF
--- a/plugin/src/org/aavso/tools/vstar/external/plugin/JDToDateTool.java
+++ b/plugin/src/org/aavso/tools/vstar/external/plugin/JDToDateTool.java
@@ -243,13 +243,17 @@ public class JDToDateTool extends GeneralToolPluginBase {
 		
 		// Set form fields to values corresponding to the current time
 		private void setCurrentTime() {
-			fieldJulianDay.setValue(julianDayNow());
-			setDateFromJd();
-			setJdFromDate(); // to synchronize fields after rounding seconds.
+			double jd = julianDayNow();
+			setDateFromJd(jd);			
+			setJdFromDate(); // to synchronize after rounding of seconds
 		}
 
 		// Date/Time fields (YYYY-MM-DD HH:MM:SS) from Julian Day field 
 		private void setDateFromJd() {
+			setDateFromJd(getAndCheck(fieldJulianDay));
+		}
+		
+		private void setDateFromJd(Double jd) {
 			yearField.setValue(null);
 			monthField.setValue(null);
 			dayField.setValue(null);
@@ -257,14 +261,14 @@ public class JDToDateTool extends GeneralToolPluginBase {
 			minField.setValue(null);
 			secField.setValue(null);
 			
-			Double jd = getAndCheck(fieldJulianDay);
-			if (jd == null) return;
+			if (jd == null) return; 
 			
 			YMD ymd = AbstractDateUtil.getInstance().jdToYMD(jd);
 			double day = ymd.getDay();
 			int hour = (int)((day - (int)day) * 24.0);
 			int min = (int)((day - (int)day - hour / 24.0) * 24.0 * 60.0);
 			double sec = ((day - (int)day - hour / 24.0 - min / 24.0 / 60.0) * 24.0 * 60.0 * 60.0);
+			if (sec > 59.99) sec = 59.99; // rounding issue: if a value = 59.996 (for example) it will be rounded to 60.
 			yearField.setValue(ymd.getYear());
 			monthField.setValue(ymd.getMonth());
 			dayField.setValue((int)day);

--- a/plugin/src/org/aavso/tools/vstar/external/plugin/JDToDateTool.java
+++ b/plugin/src/org/aavso/tools/vstar/external/plugin/JDToDateTool.java
@@ -3,35 +3,62 @@
  */
 package org.aavso.tools.vstar.external.plugin;
 
-import javax.swing.JOptionPane;
+import java.awt.BorderLayout;
+import java.awt.Container;
+import java.awt.Dialog;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyEvent;
+import java.time.Instant;
+import java.time.YearMonth;
+
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.Icon;
+import javax.swing.JButton;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import javax.swing.KeyStroke;
 
 import org.aavso.tools.vstar.plugin.GeneralToolPluginBase;
 import org.aavso.tools.vstar.ui.dialog.MessageBox;
+import org.aavso.tools.vstar.ui.dialog.NumberFieldBase;
+import org.aavso.tools.vstar.ui.mediator.DocumentManager;
+import org.aavso.tools.vstar.ui.mediator.Mediator;
+import org.aavso.tools.vstar.ui.resources.ResourceAccessor;
 import org.aavso.tools.vstar.util.date.AbstractDateUtil;
-import org.aavso.tools.vstar.util.locale.NumberParser;
+import org.aavso.tools.vstar.util.date.YMD;
+import org.aavso.tools.vstar.util.prefs.NumericPrecisionPrefs;
+import org.aavso.tools.vstar.ui.dialog.DoubleField;
+import org.aavso.tools.vstar.ui.dialog.IntegerField;
 
 /**
- * A general tool plugin that converts a JD to a calendar date.
+ * A general tool plug-in that converts a JD to a calendar date and vice versa.
  */
 public class JDToDateTool extends GeneralToolPluginBase {
+	
+	// JD <-> Date conversion procedures used here gives results differ from ones given by the
+	// AAVSO JD Calculator (https://www.aavso.org/jd-calculator) for years < 1583.
+	// This probably connected with the introduction of the Gregorian Calendar that year.
+	// (1583 (MDLXXXIII) was a common year starting on Saturday of the Gregorian calendar -- Wikipedia)	
+	// So I (PMAK) restricted the date range.
+	// Min Date = 1600-01-01T00:00:00
+	// Max Date = 9999-12-31T00:00:00
+	
+	private static int MIN_YEAR = 1600;
+	private static int MAX_YEAR = 9999;
+	
+	// Julian day of the Java Epoch 1970-01-01T00:00:00Z
+	private static double JAVA_EPOCH_JD = 2440587.5;
 
 	@Override
 	public void invoke() {
-		String str = JOptionPane.showInputDialog("Enter JD");
-		if (str != null && str.trim().length() != 0) {
-			try {
-				double jd = NumberParser.parseDouble(str);
-				String cal = AbstractDateUtil.getInstance().jdToCalendar(jd);
-				MessageBox.showMessageDialog("JD to Calendar Date", String
-						.format("%1.4f => %s", jd, cal));
-			} catch (NumberFormatException e) {
-				MessageBox.showErrorDialog("JD Error", String.format(
-						"'%s' is not a number.", str));
-			} catch (IllegalArgumentException e) {
-				MessageBox.showErrorDialog("JD Error", String.format(
-						"'%s' is an invalid JD: %s", str, e.getMessage()));
-			}
-		}
+		new JDToDateDialog();
 	}
 
 	@Override
@@ -43,4 +70,302 @@ public class JDToDateTool extends GeneralToolPluginBase {
 	public String getDisplayName() {
 		return "JD to Calendar Date";
 	}
+	
+	// Current Julian Day value
+    private static double julianDayNow()
+    {
+        return Instant.now().getEpochSecond() / (24.0 * 60.0 * 60.0) + JAVA_EPOCH_JD;
+        
+    }
+	
+	@SuppressWarnings("serial")
+	class JDToDateDialog extends JDialog {
+		private static final String sTITLE = "JD <-> Calendar Date";
+		private DoubleFieldTime fieldJulianDay;
+		private IntegerField yearField;
+		private IntegerField monthField;
+		private IntegerField dayField;
+		private IntegerField hourField;
+		private IntegerField minField;
+		private IntegerField secField;
+		
+		/**
+		 * Constructor
+		 */
+		public JDToDateDialog()	{
+			super(DocumentManager.findActiveWindow());
+			setTitle(sTITLE);
+			setModalityType(Dialog.ModalityType.MODELESS);
+			
+			ActionListener cancelListener = createCancelButtonListener();
+		    getRootPane().registerKeyboardAction(cancelListener, 
+		    		KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), 
+		    		JComponent.WHEN_IN_FOCUSED_WINDOW);
+			
+
+			Container contentPane = this.getContentPane();
+
+			JPanel topPane = new JPanel();
+			topPane.setLayout(new BoxLayout(topPane, BoxLayout.PAGE_AXIS));
+			topPane.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
+
+			topPane.add(createJulianDayPane());
+			topPane.add(createButtonPane1());
+			topPane.add(createDatePane());
+			topPane.add(createButtonPane2(cancelListener));
+			
+			contentPane.add(topPane);
+			
+			setCurrentTime();			
+		    
+			this.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
+			
+			this.pack();
+			setLocationRelativeTo(Mediator.getUI().getContentPane());
+			this.setVisible(true);
+		}
+		
+		private JTextField setTextFieldPreferredSize(JTextField textField, String sampleText) {
+			int w = textField.getFontMetrics(textField.getFont()).stringWidth(sampleText);
+			int h = textField.getPreferredSize().height;
+			textField.setPreferredSize(new Dimension(w, h));
+			return textField;
+		}
+		
+		private JPanel createJulianDayPane() {
+			JPanel panel = new JPanel(new BorderLayout());
+			fieldJulianDay = new DoubleFieldTime("Julian Day", 
+					AbstractDateUtil.getInstance().calendarToJD(MIN_YEAR, 1, 1), 
+					AbstractDateUtil.getInstance().calendarToJD(MAX_YEAR, 12, 31),
+					0.0);
+			panel.add(fieldJulianDay.getUIComponent(), BorderLayout.CENTER);
+			return panel;
+		}
+		
+		private JPanel createDatePane() {
+			JPanel panel = new JPanel(new FlowLayout());
+
+			yearField = new IntegerField("Year", MIN_YEAR, MAX_YEAR, 0);
+			panel.add(setTextFieldPreferredSize((JTextField)(yearField.getUIComponent()), "WWWWW"));
+			
+			monthField = new IntegerField("Mon", 1, 12, 0);
+			panel.add(setTextFieldPreferredSize((JTextField)(monthField.getUIComponent()), "WWWW"));
+			
+			dayField = new IntegerField("Day", 1, 31, 0);
+			panel.add(setTextFieldPreferredSize((JTextField)(dayField.getUIComponent()), "WWWW"));
+			
+			panel.add(new JLabel("  "));
+			
+			hourField = new IntegerField("Hr", 0, 23, 0);
+			panel.add(setTextFieldPreferredSize((JTextField)(hourField.getUIComponent()), "WWWW"));
+			
+			minField = new IntegerField("Min", 0, 59, 0);
+			panel.add(setTextFieldPreferredSize((JTextField)(minField.getUIComponent()), "WWWW"));
+			
+			secField = new IntegerField("Sec", 0, 59, 0);
+			panel.add(setTextFieldPreferredSize((JTextField)(secField.getUIComponent()), "WWWW"));
+			return panel;
+		}
+
+		private JButton createIconButton(Icon icon) {
+			JButton button = new JButton(icon);
+			button.setPreferredSize(new Dimension(icon.getIconWidth() + 4, icon.getIconHeight() + 4));
+			return button;
+		}
+		
+		private JPanel createButtonPane1() {
+			Icon panUpIcon = ResourceAccessor.getIconResource("/nico/toolbarIcons/_24_/UpArrow.png");
+			Icon panDownIcon = ResourceAccessor.getIconResource("/nico/toolbarIcons/_24_/DownArrow.png");
+			
+			JPanel panel = new JPanel(new FlowLayout());
+
+			JButton jDtoDateButton = createIconButton(panDownIcon);
+			jDtoDateButton.addActionListener(createJdToDateListener());
+			panel.add(jDtoDateButton);
+			
+			panel.add(new JLabel("    "));
+			
+			JButton dateToJdButton = createIconButton(panUpIcon);
+			dateToJdButton.addActionListener(createDateToJdListener());
+			panel.add(dateToJdButton);
+			
+			return panel;
+		}
+		
+		private JPanel createButtonPane2(ActionListener cancelListener) {
+			JPanel panel = new JPanel(new BorderLayout());
+			
+			JButton cancelButton = new JButton("Close");
+			cancelButton.addActionListener(cancelListener);
+			panel.add(cancelButton, BorderLayout.LINE_START);
+			
+			JButton timeNowButton = new JButton("Current Time (UT)");			
+			timeNowButton.addActionListener(createTimeNowButtonListener());
+			panel.add(timeNowButton, BorderLayout.LINE_END);
+			
+			return panel;
+		}
+		
+		// Return a listener for the "Now" button.
+		private ActionListener createTimeNowButtonListener() {
+			return new ActionListener() {
+				public void actionPerformed(ActionEvent e) {
+					setCurrentTime();
+				}
+			};
+		}
+		
+		// Return a listener for the "Close" button.
+		private ActionListener createCancelButtonListener() {
+			return new ActionListener() {
+				public void actionPerformed(ActionEvent e) {
+					setVisible(false);
+					dispose();
+				}
+			};
+		}
+
+		// Return a listener for the "JD to Date" button.
+		private ActionListener createJdToDateListener() {
+			return new ActionListener() {
+				public void actionPerformed(ActionEvent e) {
+					setDateFromJd();
+				}
+			};
+		}
+
+		// Return a listener for the "Date to JD" button.
+		private ActionListener createDateToJdListener() {
+			return new ActionListener() {
+				public void actionPerformed(ActionEvent e) {
+					setJdFromDate();
+				}
+			};
+		}
+		
+		// Set form fields to values corresponding to the current time
+		private void setCurrentTime() {
+			fieldJulianDay.setValue(julianDayNow());
+			setDateFromJd();
+			setJdFromDate(); // to synchronize fields after rounding seconds.
+		}
+
+		// Date/Time fields (YYYY-MM-DD HH:MM:SS) from Julian Day field 
+		private void setDateFromJd() {
+			yearField.setValue(null);
+			monthField.setValue(null);
+			dayField.setValue(null);
+			hourField.setValue(null);
+			minField.setValue(null);
+			secField.setValue(null);
+			Double jd;
+			try {
+				jd = fieldJulianDay.getValue();
+			} catch (Exception e) {
+				// We should never be here as soon as getValue() catches all possible exceptions.
+				jd = null;
+			}
+			if (jd != null) {
+				YMD ymd = AbstractDateUtil.getInstance().jdToYMD(jd);
+				double day = ymd.getDay();
+				int hour = (int)((day - (int)day) * 24.0);
+				int min = (int)((day - (int)day - hour / 24.0) * 24.0 * 60.0);
+				int sec = (int)((day - (int)day - hour / 24.0 - min / 24.0 / 60.0) * 24.0 * 60.0 * 60.0);
+				yearField.setValue(ymd.getYear());
+				monthField.setValue(ymd.getMonth());
+				dayField.setValue((int)day);
+				hourField.setValue(hour);
+				minField.setValue(min);
+				secField.setValue(sec);
+			} else {
+				MessageBox.showErrorDialog("Error", fieldJulianDay.getName() + ": Invalid value!\n" + numberFieldInfo(fieldJulianDay));
+				(fieldJulianDay.getUIComponent()).requestFocus();
+				((JTextField)(fieldJulianDay.getUIComponent())).selectAll();
+			}
+		}
+		
+		// Get value of IntegerField, show message in case of error and set focus to the field
+		Integer getAndCheck(IntegerField input) {
+			Integer i;
+			try {
+				i = input.getValue();
+			} catch (Exception e) {
+				// We should never be here as soon as getValue catches parseInteger() exceptions.  
+				i = null;
+			}
+			if (i == null) {
+				MessageBox.showErrorDialog("Error", input.getName() + ": Invalid value!\n" + numberFieldInfo(input));				
+				(input.getUIComponent()).requestFocus();
+				((JTextField)(input.getUIComponent())).selectAll();
+			}
+			return i;
+		}
+		
+		// Set Julian Day field to a value calculated from date fields (YYYY-MM-DD HH:MM:SS) 
+		private void setJdFromDate() {
+			fieldJulianDay.setValue(null);
+			
+			Integer year =	getAndCheck(yearField);
+			if (year == null) return;
+			
+			Integer month = getAndCheck(monthField);
+			if (month == null) return;
+			
+			Integer day = getAndCheck(dayField);
+			YearMonth yearMonthObject = YearMonth.of(year, month);
+			int daysInMonth = yearMonthObject.lengthOfMonth();
+			if (day > daysInMonth) {
+				MessageBox.showErrorDialog("Error", dayField.getName() + ": Invalid number of days in the month!");
+				(dayField.getUIComponent()).requestFocus();
+				((JTextField)(dayField.getUIComponent())).selectAll();
+				day = null;
+			}
+			if (day == null) return;
+			
+			Integer hour = getAndCheck(hourField);
+			if (hour == null) return;
+
+			Integer min = getAndCheck(minField);
+			if (min == null) return;
+
+			Integer sec = getAndCheck(secField);
+			if (sec == null) return;
+
+			double dday = day + hour / 24.0 + min / 24.0 / 60.0 + sec / 24.0 / 60.0 / 60.0;   
+			double jd = AbstractDateUtil.getInstance().calendarToJD(year, month, dday);
+			
+			fieldJulianDay.setValue(jd);
+		}
+		
+	}
+	
+	private String numberFieldInfo(NumberFieldBase<?> field) {
+		String s = "";
+		if (field.getMin() == null && field.getMax() != null)
+			s = "Only values <= " + field.getMax() + " allowed.";
+		else if (field.getMin() != null && field.getMax() == null)
+			s = "Only values >= " + field.getMin() + " allowed.";
+		else if (field.getMin() != null && field.getMax() != null)
+			s = "Only values between " + field.getMin() + " and " + field.getMax() + " allowed.";
+		return s; 
+	}
+	
+	/*
+	 * Unlike DoubleField, DoubleFieldTime uses 'timeOutputFormat' instead of 'otherOutputFormat'
+	 */
+	private class DoubleFieldTime extends DoubleField {
+
+		public DoubleFieldTime(String name, Double min, Double max, Double initial) {
+			super(name, min, max, initial);
+			setValue(initial); // because super() uses NumericPrecisionPrefs.getOtherOutputFormat()
+		}
+
+		@Override
+		public void setValue(Double value) {
+			textField.setText(value == null ? "" : NumericPrecisionPrefs.getTimeOutputFormat().format(value));
+		}
+		
+	}
+
+
 }

--- a/plugin/src/org/aavso/tools/vstar/external/plugin/JDToDateTool.java
+++ b/plugin/src/org/aavso/tools/vstar/external/plugin/JDToDateTool.java
@@ -138,24 +138,24 @@ public class JDToDateTool extends GeneralToolPluginBase {
 			JPanel panel = new JPanel(new FlowLayout());
 
 			yearField = new IntegerField("Year", MIN_YEAR, MAX_YEAR, 0);
-			panel.add(setTextFieldPreferredSize((JTextField)(yearField.getUIComponent()), "WWWWW"));
+			panel.add(setNumberFieldColumns(yearField, 5));
 			
 			monthField = new IntegerField("Mon", 1, 12, 0);
-			panel.add(setTextFieldPreferredSize((JTextField)(monthField.getUIComponent()), "WWWW"));
+			panel.add(setNumberFieldColumns(monthField, 4));
 			
 			dayField = new IntegerField("Day", 1, 31, 0);
-			panel.add(setTextFieldPreferredSize((JTextField)(dayField.getUIComponent()), "WWWW"));
+			panel.add(setNumberFieldColumns(dayField, 4));
 			
 			panel.add(new JLabel("  "));
 			
 			hourField = new IntegerField("Hr", 0, 23, 0);
-			panel.add(setTextFieldPreferredSize((JTextField)(hourField.getUIComponent()), "WWWW"));
+			panel.add(setNumberFieldColumns(hourField, 4));
 			
 			minField = new IntegerField("Min", 0, 59, 0);
-			panel.add(setTextFieldPreferredSize((JTextField)(minField.getUIComponent()), "WWWW"));
+			panel.add(setNumberFieldColumns(minField, 4));
 			
 			secField = new DoubleFieldSeconds("Sec", 0.0, 59.99, 0.00);
-			panel.add(setTextFieldPreferredSize((JTextField)(secField.getUIComponent()), "WWWWW"));
+			panel.add(setNumberFieldColumns(secField, 5));
 			return panel;
 		}
 
@@ -229,13 +229,12 @@ public class JDToDateTool extends GeneralToolPluginBase {
 			};
 		}
 		
-		private JTextField setTextFieldPreferredSize(JTextField textField, String sampleText) {
-			int w = textField.getFontMetrics(textField.getFont()).stringWidth(sampleText);
-			int h = textField.getPreferredSize().height;
-			textField.setPreferredSize(new Dimension(w, h));
+		private JTextField setNumberFieldColumns(NumberFieldBase<?> field, int columns) {
+			JTextField textField = (JTextField)(field.getUIComponent());
+			textField.setColumns(columns);
 			return textField;
 		}
-		
+	
 		private JButton createIconButton(Icon icon) {
 			JButton button = new JButton(icon);
 			button.setPreferredSize(new Dimension(icon.getIconWidth() + 4, icon.getIconHeight() + 4));

--- a/plugin/src/org/aavso/tools/vstar/external/plugin/JDToDateTool.java
+++ b/plugin/src/org/aavso/tools/vstar/external/plugin/JDToDateTool.java
@@ -50,11 +50,11 @@ public class JDToDateTool extends GeneralToolPluginBase {
 	// Min Date = 1600-01-01T00:00:00
 	// Max Date = 9999-12-31T00:00:00
 	
-	private static int MIN_YEAR = 1600;
-	private static int MAX_YEAR = 9999;
+	private static final int MIN_YEAR = 1600;
+	private static final int MAX_YEAR = 9999;
 	
 	// Julian day of the Java Epoch 1970-01-01T00:00:00Z
-	private static double JAVA_EPOCH_JD = 2440587.5;
+	private static final double JAVA_EPOCH_JD = 2440587.5;
 
 	@Override
 	public void invoke() {
@@ -75,7 +75,6 @@ public class JDToDateTool extends GeneralToolPluginBase {
     private static double julianDayNow()
     {
         return Instant.now().getEpochSecond() / (24.0 * 60.0 * 60.0) + JAVA_EPOCH_JD;
-        
     }
 	
 	@SuppressWarnings("serial")
@@ -101,7 +100,6 @@ public class JDToDateTool extends GeneralToolPluginBase {
 		    getRootPane().registerKeyboardAction(cancelListener, 
 		    		KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), 
 		    		JComponent.WHEN_IN_FOCUSED_WINDOW);
-			
 
 			Container contentPane = this.getContentPane();
 
@@ -123,13 +121,6 @@ public class JDToDateTool extends GeneralToolPluginBase {
 			this.pack();
 			setLocationRelativeTo(Mediator.getUI().getContentPane());
 			this.setVisible(true);
-		}
-		
-		private JTextField setTextFieldPreferredSize(JTextField textField, String sampleText) {
-			int w = textField.getFontMetrics(textField.getFont()).stringWidth(sampleText);
-			int h = textField.getPreferredSize().height;
-			textField.setPreferredSize(new Dimension(w, h));
-			return textField;
 		}
 		
 		private JPanel createJulianDayPane() {
@@ -167,12 +158,6 @@ public class JDToDateTool extends GeneralToolPluginBase {
 			return panel;
 		}
 
-		private JButton createIconButton(Icon icon) {
-			JButton button = new JButton(icon);
-			button.setPreferredSize(new Dimension(icon.getIconWidth() + 4, icon.getIconHeight() + 4));
-			return button;
-		}
-		
 		private JPanel createButtonPane1() {
 			Icon panUpIcon = ResourceAccessor.getIconResource("/nico/toolbarIcons/_24_/UpArrow.png");
 			Icon panDownIcon = ResourceAccessor.getIconResource("/nico/toolbarIcons/_24_/DownArrow.png");
@@ -243,6 +228,19 @@ public class JDToDateTool extends GeneralToolPluginBase {
 			};
 		}
 		
+		private JTextField setTextFieldPreferredSize(JTextField textField, String sampleText) {
+			int w = textField.getFontMetrics(textField.getFont()).stringWidth(sampleText);
+			int h = textField.getPreferredSize().height;
+			textField.setPreferredSize(new Dimension(w, h));
+			return textField;
+		}
+		
+		private JButton createIconButton(Icon icon) {
+			JButton button = new JButton(icon);
+			button.setPreferredSize(new Dimension(icon.getIconWidth() + 4, icon.getIconHeight() + 4));
+			return button;
+		}
+		
 		// Set form fields to values corresponding to the current time
 		private void setCurrentTime() {
 			fieldJulianDay.setValue(julianDayNow());
@@ -284,23 +282,6 @@ public class JDToDateTool extends GeneralToolPluginBase {
 			}
 		}
 		
-		// Get value of IntegerField, show message in case of error and set focus to the field
-		Integer getAndCheck(IntegerField input) {
-			Integer i;
-			try {
-				i = input.getValue();
-			} catch (Exception e) {
-				// We should never be here as soon as getValue catches parseInteger() exceptions.  
-				i = null;
-			}
-			if (i == null) {
-				MessageBox.showErrorDialog("Error", input.getName() + ": Invalid value!\n" + numberFieldInfo(input));				
-				(input.getUIComponent()).requestFocus();
-				((JTextField)(input.getUIComponent())).selectAll();
-			}
-			return i;
-		}
-		
 		// Set Julian Day field to a value calculated from date fields (YYYY-MM-DD HH:MM:SS) 
 		private void setJdFromDate() {
 			fieldJulianDay.setValue(null);
@@ -337,19 +318,38 @@ public class JDToDateTool extends GeneralToolPluginBase {
 			fieldJulianDay.setValue(jd);
 		}
 		
+		// Get value of IntegerField, show message in case of error and set focus to the field
+		private Integer getAndCheck(IntegerField input) {
+			Integer i;
+			try {
+				i = input.getValue();
+			} catch (Exception e) {
+				// We should never be here as soon as getValue catches parseInteger() exceptions.  
+				i = null;
+			}
+			if (i == null) {
+				MessageBox.showErrorDialog("Error", input.getName() + ": Invalid value!\n" +
+						"Value must be integer.\n" +
+						numberFieldInfo(input));				
+				(input.getUIComponent()).requestFocus();
+				((JTextField)(input.getUIComponent())).selectAll();
+			}
+			return i;
+		}
+		
+		private String numberFieldInfo(NumberFieldBase<?> field) {
+			String s = "";
+			if (field.getMin() == null && field.getMax() != null)
+				s = "Only values <= " + field.getMax() + " allowed.";
+			else if (field.getMin() != null && field.getMax() == null)
+				s = "Only values >= " + field.getMin() + " allowed.";
+			else if (field.getMin() != null && field.getMax() != null)
+				s = "Only values between " + field.getMin() + " and " + field.getMax() + " allowed.";
+			return s; 
+		}
+		
 	}
-	
-	private String numberFieldInfo(NumberFieldBase<?> field) {
-		String s = "";
-		if (field.getMin() == null && field.getMax() != null)
-			s = "Only values <= " + field.getMax() + " allowed.";
-		else if (field.getMin() != null && field.getMax() == null)
-			s = "Only values >= " + field.getMin() + " allowed.";
-		else if (field.getMin() != null && field.getMax() != null)
-			s = "Only values between " + field.getMin() + " and " + field.getMax() + " allowed.";
-		return s; 
-	}
-	
+
 	/*
 	 * Unlike DoubleField, DoubleFieldTime uses 'timeOutputFormat' instead of 'otherOutputFormat'
 	 */
@@ -366,6 +366,5 @@ public class JDToDateTool extends GeneralToolPluginBase {
 		}
 		
 	}
-
 
 }

--- a/src/org/aavso/tools/vstar/ui/dialog/DoubleField.java
+++ b/src/org/aavso/tools/vstar/ui/dialog/DoubleField.java
@@ -59,12 +59,15 @@ public class DoubleField extends NumberFieldBase<Double> {
 		try {
 			value = NumberParser.parseDouble(textField.getText());
 
+			// In the previous realization, null is assigned to the value if value < min.
+			// Then in the next 'if' the null value is compared with max, this leads to Null Pointer Exception.
+			
 			if (min != null && value < min) {
-				value = null;
+				return null;
 			}
 
 			if (max != null && value > max) {
-				value = null;
+				return null;
 			}
 		} catch (NumberFormatException e) {
 			// Nothing to do; return null.

--- a/src/org/aavso/tools/vstar/ui/dialog/IntegerField.java
+++ b/src/org/aavso/tools/vstar/ui/dialog/IntegerField.java
@@ -20,6 +20,8 @@ package org.aavso.tools.vstar.ui.dialog;
 import java.text.NumberFormat;
 
 import org.aavso.tools.vstar.util.locale.NumberParser;
+import org.aavso.tools.vstar.vela.VeLaEvalError;
+import org.aavso.tools.vstar.vela.VeLaParseError;
 
 /**
  * This class encapsulates the name, range, and value of an integer text
@@ -54,15 +56,22 @@ public class IntegerField extends NumberFieldBase<Integer> {
 
 		try {
 			value = (int) NumberParser.parseInteger(textField.getText());
-
+			
+			// In the previous realization, null is assigned to the value if value < min.
+			// Then in the next 'if' the null value is compared with max, this leads to Null Pointer Exception.
+			
 			if (min != null && value < min) {
-				value = null;
+				return null;
 			}
 
 			if (max != null && value > max) {
-				value = null;
+				return null;
 			}
 		} catch (NumberFormatException e) {
+			// Nothing to do; return null.
+		} catch (VeLaParseError e) { // #PMAK#
+			// Nothing to do; return null.
+		} catch (VeLaEvalError e) { // #PMAK#
 			// Nothing to do; return null.
 		}
 


### PR DESCRIPTION
Hi @dbenn ,

I've made a completely new "JD to Calendar date" plug-in (see Issue #208).
It is bidirectional, one can convert from JD to Date/Time and vice versa.
![image](https://user-images.githubusercontent.com/44919945/146749786-8fcc2fa6-b11f-4c39-82f9-9ffcc07f626c.png)


I also patched DoubleField.java and IntegerField.java. There was a bug in both classes that could cause Null Pointer Exception: I replaced null assignment to the variable by the 'return null' statement to avoid comparison of null with a variable.

Also, I've added 'catch (VeLaParseError e)' and 'catch (VeLaEvalError e)' in IntegerField.getValue() like in DoubleField.getValue(). Those exceptions can be thrown by NumberParser.parseInteger().