### PR TITLE
Issue #215 fix

### DIFF
--- a/src/org/aavso/tools/vstar/ui/dialog/model/HarmonicPeriodPane.java
+++ b/src/org/aavso/tools/vstar/ui/dialog/model/HarmonicPeriodPane.java
@@ -31,6 +31,8 @@ import javax.swing.JTextField;
 import org.aavso.tools.vstar.util.locale.NumberParser;
 import org.aavso.tools.vstar.util.model.Harmonic;
 import org.aavso.tools.vstar.util.prefs.NumericPrecisionPrefs;
+import org.aavso.tools.vstar.vela.VeLaEvalError;
+import org.aavso.tools.vstar.vela.VeLaParseError;
 
 /**
  * This component defines a pane that shows a period and a combo-box requesting
@@ -103,6 +105,10 @@ public class HarmonicPeriodPane extends JPanel {
 		try {
 			period = NumberParser.parseDouble(periodText);
 		} catch (NumberFormatException e) {
+			// Nothing to do; return null.
+		} catch (VeLaParseError e) { // #PMAK#
+			// Nothing to do; return null.
+		} catch (VeLaEvalError e) { // #PMAK#
 			// Nothing to do; return null.
 		}
 


### PR DESCRIPTION
Issue #215 fix: 
1) HarmonicPeriodPane: catching parseDouble() exceptions (like in DoubleField class; 
2) FourierModelCreator: handling all possible exceptions in getModel().

to-do: replace 'JTextField periodField' by DoubleFiled?