### PR TITLE
Issue #224 fix: getObservationRetriever() returns null if parameter dialog is canceled (if present) that is, in fact, equivalent to CancellationException

### DIFF
--- a/src/org/aavso/tools/vstar/ui/task/NewStarFromObSourcePluginTask.java
+++ b/src/org/aavso/tools/vstar/ui/task/NewStarFromObSourcePluginTask.java
@@ -228,6 +228,14 @@ public class NewStarFromObSourcePluginTask extends SwingWorker<Void, Void> {
 			// the number of records, we can show updated progress,
 			// otherwise just show busy state.
 			retriever = obSourcePlugin.getObservationRetriever();
+			
+			// #PMAK#20211229#1#:
+			//	if the retriever has configuration dialog (see, for example, ASAS-SN plug-in)
+			//  that was canceled, getObservationRetriever() returns null.
+			//  It is essentially the same as CancellationException
+			//  that cannot be thrown from within getObservationRetriever()
+			if (retriever == null)
+				cancelled = true;
 		} catch (CancellationException ex) {
 			cancelled = true;
 		} catch (ConnectionException ex) {


### PR DESCRIPTION
With this fix, cancellation of the Parameters dialog (if present) in getObservationRetriever() is equivalent to throw CancellationException. This exception currently cannot be thrown from within getObservationRetriever() (we need to add throws to the declaration of the base class too, however with this fix it is not needed)

Now the observation source plug-ins behave consistently (like New Star from AAVSO database plug-in): when dialog is canceled, the toolbar buttons get active (along with menu items). However, they are activated in any case, even if no observations are loaded!
Note: This bug existed _before_ this fix and is not related to it directly: the logic of enabling/disabling the interface elements has issues (probably, a new issue should be created).