### PR TITLE
Issue 229 expressionvisitor parsedouble bug

### DIFF
--- a/src/org/aavso/tools/vstar/vela/ExpressionVisitor.java
+++ b/src/org/aavso/tools/vstar/vela/ExpressionVisitor.java
@@ -439,6 +439,7 @@ public class ExpressionVisitor extends VeLaBaseVisitor<AST> {
 			DecimalFormatSymbols dfs = new DecimalFormatSymbols(Locale.getDefault());
 			dfs.setExponentSeparator("E"); // may differ for some locales
 			DecimalFormat FORMAT = new DecimalFormat("", dfs);
+			FORMAT.setGroupingUsed(false); // Suppress grouping (to avoid grouping symbol ambiguity)
 			ParsePosition parsePosition = new ParsePosition(0);
 
 			str = str.trim();

--- a/src/org/aavso/tools/vstar/vela/ExpressionVisitor.java
+++ b/src/org/aavso/tools/vstar/vela/ExpressionVisitor.java
@@ -17,8 +17,9 @@
  */
 package org.aavso.tools.vstar.vela;
 
-import java.text.NumberFormat;
-import java.text.ParseException;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.ParsePosition;
 import java.util.Locale;
 
 import org.aavso.tools.vstar.vela.VeLaParser.AdditiveExpressionContext;
@@ -432,29 +433,40 @@ public class ExpressionVisitor extends VeLaBaseVisitor<AST> {
 	 *             If no valid double value is present.
 	 */
 	private double parseDouble(String str) throws NumberFormatException {
-		NumberFormat FORMAT = NumberFormat.getNumberInstance(Locale
-				.getDefault());
-
 		if (str == null) {
 			throw new NumberFormatException("String was null");
 		} else {
-			try {
-				str = str.trim();
+			DecimalFormatSymbols dfs = new DecimalFormatSymbols(Locale.getDefault());
+			dfs.setExponentSeparator("E"); // may differ for some locales
+			DecimalFormat FORMAT = new DecimalFormat("", dfs);
+			ParsePosition parsePosition = new ParsePosition(0);
 
-				if (str.startsWith("+")) {
-					// Leading "+" causes an exception to be thrown.
-					str = str.substring(1);
-				}
+			str = str.trim();
 
-				if (str.contains("e")) {
-					// Convert exponential indicator to parsable form.
-					str = str.toUpperCase();
-				}
-
-				return FORMAT.parse(str).doubleValue();
-			} catch (ParseException e) {
-				throw new NumberFormatException(e.getLocalizedMessage());
+			if (str.startsWith("+")) {
+				// Leading "+" causes an exception to be thrown.
+				str = str.substring(1);
 			}
+
+			if (str.contains("e")) {
+				// Convert exponential indicator to parsable form.
+				str = str.toUpperCase();
+			}
+
+			// We use parsePosition to be sure that the input string is parsed to the end.
+			// Without parsePosition the parse() method may return a valid result for
+			// a part of the string (parsing is terminated at the first invalid symbol).
+			// For example, a string "1.234" parsed under uk_UA, fr_FR, or other European locales
+			// without parsePosition is converted to 1. If parsePosition is used, we can check
+			// if the string is parsed completely and throw an exception if not.
+			Number number = FORMAT.parse(str, parsePosition);
+			if (number == null) {
+				throw new NumberFormatException("Failed to parse: " + str);
+			}
+			if (parsePosition.getIndex() < str.length()) {
+				throw new NumberFormatException("Failed to parse the full string: " + str);
+			}
+			return number.doubleValue();
 		}
 	}
 }


### PR DESCRIPTION
@dbenn ,

I made additional changes in ExpressionVisitor.parseDouble to make it more error-proof. Please see the comments in the source code. Could you please make unit tests for it?

I also checked if the locale affects _output_ formats used for generating textual representations of models.
The exponential format used for polynomial models (NumericPrecisionPrefs.formatScientific()) utilizes String.format() method.
Interestingly that it always uses normal Latin E for exponent regardless of locale (even for Ukrainian uk_UA while DecimalFormat.format prints Cyrillic Е for the scientific formats like "#.########E0" (Java ver>8), fortunately, we never use it in VStar).
So model expressions in the "Model information" are correct independently on the Java version and locale (I hope so).

