### PR TITLE
NumericPrecisionPrefs output format compatible with ExpressionVisitor input one.

### DIFF
--- a/src/org/aavso/tools/vstar/util/prefs/NumericPrecisionPrefs.java
+++ b/src/org/aavso/tools/vstar/util/prefs/NumericPrecisionPrefs.java
@@ -306,9 +306,10 @@ public class NumericPrecisionPrefs {
 	}
 
 	private static DecimalFormat getOutputFormat(int decimalPlaces) {
-		DecimalFormat decFormatter = new DecimalFormat(
-				getFormatString(decimalPlaces), new DecimalFormatSymbols(Locale
-						.getDefault()));
+		DecimalFormatSymbols dfs = new DecimalFormatSymbols(Locale.getDefault());
+		dfs.setExponentSeparator("E"); // may differ for some locales
+		dfs.setMinusSign('-'); // "nn" locale fails without this
+		DecimalFormat decFormatter = new DecimalFormat(getFormatString(decimalPlaces), dfs);
 
 		return decFormatter;
 	}


### PR DESCRIPTION
Output DecimalFormatSymbols are now the same as input ones.

Besides DecimalFormat, NumericPrecisionPrefs uses String.format() for values with exponents (used in polynomial models). Interestingly that String.format() does not suffer from Java version-to-version incompatibility like DecimalFormat. Although this is an inconsistency within the Java libraries themselves.