### PR TITLE
#138: removed E+nn from real numbers in VeLa grammar; removed UT test…

### DIFF
--- a/src/org/aavso/tools/vstar/vela/ExpressionVisitor.java
+++ b/src/org/aavso/tools/vstar/vela/ExpressionVisitor.java
@@ -44,7 +44,6 @@ import org.aavso.tools.vstar.vela.VeLaParser.RealContext;
 import org.aavso.tools.vstar.vela.VeLaParser.RelationalExpressionContext;
 import org.aavso.tools.vstar.vela.VeLaParser.SelectionExpressionContext;
 import org.aavso.tools.vstar.vela.VeLaParser.SequenceContext;
-import org.aavso.tools.vstar.vela.VeLaParser.SignContext;
 import org.aavso.tools.vstar.vela.VeLaParser.StringContext;
 import org.aavso.tools.vstar.vela.VeLaParser.SymbolContext;
 import org.aavso.tools.vstar.vela.VeLaParser.TypeContext;
@@ -199,12 +198,6 @@ public class ExpressionVisitor extends VeLaBaseVisitor<AST> {
 		}
 
 		return ast;
-	}
-
-	@Override
-	public AST visitSign(SignContext ctx) {
-		// Nothing to do; could visit this and return AST(Operation.NEG)
-		return null;
 	}
 
 	@Override
@@ -445,13 +438,8 @@ public class ExpressionVisitor extends VeLaBaseVisitor<AST> {
 
 			str = str.trim();
 
-			if (str.startsWith("+")) {
-				// Leading "+" causes an exception to be thrown.
-				str = str.substring(1);
-			}
-
 			if (str.contains("e")) {
-				// Convert exponential indicator to parsable form.
+				// Convert exponential indicator to parsable form
 				str = str.toUpperCase();
 			}
 

--- a/src/org/aavso/tools/vstar/vela/VeLa.g4
+++ b/src/org/aavso/tools/vstar/vela/VeLa.g4
@@ -196,13 +196,7 @@ multiplicativeExpression
 
 unaryExpression
 :
-    sign? exponentiationExpression
-;
-
-sign
-:
-    MINUS
-    | PLUS
+    MINUS? exponentiationExpression
 ;
 
 exponentiationExpression

--- a/test/org/aavso/tools/vstar/util/locale/NumberParserTest.java
+++ b/test/org/aavso/tools/vstar/util/locale/NumberParserTest.java
@@ -38,7 +38,7 @@ public class NumberParserTest extends TestCase {
 	}
 
 	public void testParseExplicitPositiveRealNoFractionalComponent() {
-		commonValidTest(1000, "+1000");
+		commonValidTest(1000, "1000");
 	}
 
 	public void testParseNegativeRealNoFractionalComponent() {
@@ -62,7 +62,7 @@ public class NumberParserTest extends TestCase {
 	}
 
 	public void testParsePositiveReal2() {
-		commonValidTest(+12.25, "+12.25");
+		commonValidTest(12.25, "12.25");
 	}
 
 	public void testParseNegativeReal1() {
@@ -74,7 +74,7 @@ public class NumberParserTest extends TestCase {
 	}
 
 	public void testParseExplicitPositiveRealNoLeadingZero() {
-		commonValidTest(.25, "+.25");
+		commonValidTest(.25, ".25");
 	}
 
 	public void testParseNegativeRealNoLeadingZero() {
@@ -110,7 +110,7 @@ public class NumberParserTest extends TestCase {
 	}
 
 	public void testParseExponentialFormat6() {
-		commonValidTest(0.0225, "+2.25e-2");
+		commonValidTest(0.0225, "2.25e-2");
 	}
 
 	public void testParseExponentialFormat7() {
@@ -118,7 +118,7 @@ public class NumberParserTest extends TestCase {
 	}
 
 	public void testParseExponentialFormat8() {
-		commonValidTest(400, "+4e2");
+		commonValidTest(400, "4e2");
 	}
 
 	public void testParseExponentialFormat9() {
@@ -134,7 +134,7 @@ public class NumberParserTest extends TestCase {
 		commonValidTest(12.25, "12,25");
 		commonValidTest(-0.0225, "-2,25e-2");
 		commonValidTest(225.0, "2,25E2");
-		commonValidTest(400, "+4e2");
+		commonValidTest(400, "4e2");
 	}
 
 	private void commonValidTest(double expected, String actual) {

--- a/test/org/aavso/tools/vstar/vela/VeLaTest.java
+++ b/test/org/aavso/tools/vstar/vela/VeLaTest.java
@@ -91,12 +91,6 @@ public class VeLaTest extends TestCase {
 		commonNumericLocaleTest("3.141592E5", 314159.2, 1e-6);
 	}
 
-	// See GitHub issue #138; this is caused by an ANTLR parse error before we ever
-	// get to ExpressionVisitor.parseDouble()
-//	public void testPosExponentWithEPlus() {
-//		commonNumericLocaleTest("3.141592E+5", 314159.2, 1e-6);
-//	}
-
 	public void testNegExponent() {
 		commonNumericLocaleTest("3.141592E-1", 0.314159, 1e-6);
 	}


### PR DESCRIPTION
… case for this; also removed + as a valid numeric prefix