### PR TITLE
#49: including derived series pane

### DIFF
--- a/src/org/aavso/tools/vstar/ui/dialog/series/MultipleSeriesSelectionDialog.java
+++ b/src/org/aavso/tools/vstar/ui/dialog/series/MultipleSeriesSelectionDialog.java
@@ -68,7 +68,7 @@ public class MultipleSeriesSelectionDialog extends AbstractOkCancelDialog {
 		seriesPane = new JPanel();
 		seriesPane.setLayout(new BoxLayout(seriesPane, BoxLayout.LINE_AXIS));
 		seriesVisibilityPane = new SeriesVisibilityPane(obsPlotModel, Mediator
-				.getInstance().getAnalysisType(), false, false, false);
+				.getInstance().getAnalysisType(), true, false, false);
 		seriesPane.add(seriesVisibilityPane);
 
 		topPane.add(new JScrollPane(seriesPane));


### PR DESCRIPTION
The derived series pane has been included. Note that an observation transformer can act upon multiple series at once. This makes more sense in the context of recent changes in which new and filtered series are copied in order to avoid side effects.