### PR TITLE
#234: changed ANTLR grammar to use Greek upper/lower case lambda and …

### DIFF
--- a/src/org/aavso/tools/vstar/vela/VeLa.g4
+++ b/src/org/aavso/tools/vstar/vela/VeLa.g4
@@ -52,7 +52,7 @@ grammar VeLa;
 //     coerced to the same value; perhaps declared as list<T> or checked
 //     upon each element addition
 // - Y-combinator in VeLa **
-// - Allow a type called ANY or variant types such as (real | string | list) **
+// - Allow a type called ANY or variant types such as (real | string | list)
 // - Refinement types ala Wadler's complement to blame, e.g. f(n:real{n >= 0})
 // - Doc strings for functions; use ;; rather than -- ?
 
@@ -358,7 +358,7 @@ FUN
 ;
 
 LAMBDA
-:   '\u2C96' | '\u2C97'
+:   '\u039B' | '\u03BB'
 ;
 
 INT_T

--- a/test/org/aavso/tools/vstar/vela/VeLaTest.java
+++ b/test/org/aavso/tools/vstar/vela/VeLaTest.java
@@ -881,7 +881,7 @@ public class VeLaTest extends TestCase {
 	}
 
 	public void testAnonUpperCaseLambdaExponentiation() {
-		String prog = "Ⲗ(x:integer y:integer) : integer { x^y }(12 2)";
+		String prog = "Λ(x:integer y:integer) : integer { x^y }(12 2)";
 
 		Optional<Operand> result = vela.program(prog);
 
@@ -890,7 +890,7 @@ public class VeLaTest extends TestCase {
 	}
 
 	public void testAnonLowerCaseLambdaExponentiation() {
-		String prog = "ⲗ(x:integer y:integer) : integer { x^y }(12 2)";
+		String prog = "λ(x:integer y:integer) : integer { x^y }(12 2)";
 
 		Optional<Operand> result = vela.program(prog);
 


### PR DESCRIPTION
…updated VeLa unit test

A simple one to check @mpyat2. :) I am now surprised I didn't notice this problem when writing the unit test since I should have seen that the upper and lower case symbols just did not look correct, especially since I took a year of ancient Greek in the mid-80s. It was awhile ago though. ;)