### PR TITLE
#311: quoting comments field including escaping of quotesw

### DIFF
--- a/src/org/aavso/tools/vstar/data/ValidObservation.java
+++ b/src/org/aavso/tools/vstar/data/ValidObservation.java
@@ -1201,7 +1201,7 @@ public class ValidObservation extends Observation {
 		buf.append(delimiter);
 
 		if (this.getComments() != null) {
-			buf.append(this.getComments());
+			buf.append(quoteForCSV(this.getComments()));
 		}
 		buf.append(delimiter);
 
@@ -1430,5 +1430,17 @@ public class ValidObservation extends Observation {
 
 	private boolean isEmpty(String s) {
 		return s == null || s.trim().length() == 0;
+	}
+
+	/**
+	 * Precede any double quote in the argument with another and
+	 * wrap the whole argument in double quotes.
+	 * 
+	 * @param field The field to be quoted
+	 * @return The quoted field
+	 */
+	private String quoteForCSV(String field) {
+		field = field.replace("\"", "\"\"");
+		return "\"" + field + "\"";
 	}
 }


### PR DESCRIPTION
I have fixed the bug by quoting the comments field and escaping any double quotes in the field by preceding each with a double quote, as per the CSV spec.

I've tested that this works using the V405 Dra data set, by saving and reloading it, and also adding quotes inside a row of data to see if it loads and saving it again to ensure that escaped quotes are preserved.