### PR TITLE
Kepler/TESS and QLP observation sources were updated

### DIFF
--- a/plugin/src/org/aavso/tools/vstar/external/plugin/KeplerFITSObservationSource.java
+++ b/plugin/src/org/aavso/tools/vstar/external/plugin/KeplerFITSObservationSource.java
@@ -169,7 +169,6 @@ public class KeplerFITSObservationSource extends ObservationSourcePluginBase {
 		double time;
 		double intensity;
 		double error;
-		Double headerMagnitude;
 		Integer quality;
 	}
 
@@ -295,7 +294,6 @@ public class KeplerFITSObservationSource extends ObservationSourcePluginBase {
 							rawObs.time = hjd;
 							rawObs.intensity = flux;
 							rawObs.error = flux_err;
-							rawObs.headerMagnitude = keplerOrTessMag != invalidMag ? keplerOrTessMag : null;
 							rawObs.quality = null;
 							
 							if (fitsType == FitsType.KEPLER) {
@@ -349,8 +347,8 @@ public class KeplerFITSObservationSource extends ObservationSourcePluginBase {
 					ob.setMagnitude(new Magnitude(mag, magErr));
 					ob.setBand(keplerSeries);
 					ob.setRecordNumber(rawObs.row);
-					ob.addDetail("HEAGER_MAG", 
-							rawObs.headerMagnitude != null ? NumericPrecisionPrefs.getOtherOutputFormat().format(rawObs.headerMagnitude) : "",
+					ob.addDetail("HEAGER_MAG",
+							keplerOrTessMag != invalidMag ? NumericPrecisionPrefs.getOtherOutputFormat().format(keplerOrTessMag) : "",
 							fitsType.description);
 					ob.addDetail("QUALITY",	rawObs.quality != null ? rawObs.quality.toString() : "", "Quality");
 					collectObservation(ob);

--- a/plugin/src/org/aavso/tools/vstar/external/plugin/QLPFITSObservationSource.java
+++ b/plugin/src/org/aavso/tools/vstar/external/plugin/QLPFITSObservationSource.java
@@ -41,6 +41,7 @@ import org.aavso.tools.vstar.plugin.ObservationSourcePluginBase;
 import org.aavso.tools.vstar.ui.dialog.AbstractOkCancelDialog;
 import org.aavso.tools.vstar.ui.mediator.Mediator;
 import org.aavso.tools.vstar.ui.mediator.StarInfo;
+import org.aavso.tools.vstar.util.prefs.NumericPrecisionPrefs;
 import org.apache.commons.math.stat.descriptive.rank.Median;
 
 import nom.tam.fits.BasicHDU;
@@ -92,13 +93,13 @@ public class QLPFITSObservationSource extends ObservationSourcePluginBase {
 
 	@Override
 	public String getDescription() {
-		String str = "QLP FITS file v0.2 observation source";
+		String str = "QLP FITS file v0.3 observation source";
 		return str;
 	}
 
 	@Override
 	public String getDisplayName() {
-		String str = "New Star from QLP FITS File v0.2...";
+		String str = "New Star from QLP FITS File v0.3...";
 		return str;
 	}
 
@@ -125,6 +126,7 @@ public class QLPFITSObservationSource extends ObservationSourcePluginBase {
 		double time;
 		double intensity;
 		double error;
+		Double headerMagnitude;
 		int quality;
 	}
 
@@ -225,6 +227,8 @@ public class QLPFITSObservationSource extends ObservationSourcePluginBase {
 							rawObs.intensity = flux;
 							rawObs.error = flux_err;
 							rawObs.quality = quality;
+							rawObs.headerMagnitude = tessMag != invalidMag ? tessMag : null;
+							
 							rawObsList.add(rawObs);
 						}
 					} catch (Exception e) {
@@ -263,6 +267,10 @@ public class QLPFITSObservationSource extends ObservationSourcePluginBase {
 					ob.setMagnitude(new Magnitude(mag, magErr));
 					ob.setBand(qlpSeries);
 					ob.setRecordNumber(rawObs.row);
+					ob.addDetail("HEAGER_MAG", 
+							rawObs.headerMagnitude != null ? NumericPrecisionPrefs.getOtherOutputFormat().format(rawObs.headerMagnitude) : "",
+							"TESS magnitude");
+					
 					ob.addDetail("Quality", Integer.toString(rawObs.quality), "Quality");
 					collectObservation(ob);
 					incrementProgress();

--- a/plugin/src/org/aavso/tools/vstar/external/plugin/QLPFITSObservationSource.java
+++ b/plugin/src/org/aavso/tools/vstar/external/plugin/QLPFITSObservationSource.java
@@ -126,7 +126,6 @@ public class QLPFITSObservationSource extends ObservationSourcePluginBase {
 		double time;
 		double intensity;
 		double error;
-		Double headerMagnitude;
 		int quality;
 	}
 
@@ -227,7 +226,6 @@ public class QLPFITSObservationSource extends ObservationSourcePluginBase {
 							rawObs.intensity = flux;
 							rawObs.error = flux_err;
 							rawObs.quality = quality;
-							rawObs.headerMagnitude = tessMag != invalidMag ? tessMag : null;
 							
 							rawObsList.add(rawObs);
 						}
@@ -267,8 +265,8 @@ public class QLPFITSObservationSource extends ObservationSourcePluginBase {
 					ob.setMagnitude(new Magnitude(mag, magErr));
 					ob.setBand(qlpSeries);
 					ob.setRecordNumber(rawObs.row);
-					ob.addDetail("HEAGER_MAG", 
-							rawObs.headerMagnitude != null ? NumericPrecisionPrefs.getOtherOutputFormat().format(rawObs.headerMagnitude) : "",
+					ob.addDetail("HEAGER_MAG",
+							tessMag != invalidMag ? NumericPrecisionPrefs.getOtherOutputFormat().format(tessMag) : "",
 							"TESS magnitude");
 					
 					ob.addDetail("Quality", Integer.toString(rawObs.quality), "Quality");


### PR DESCRIPTION
In response to #314: Kepler/TESS and QLP observation sources were updated: reference Kepler or TESS magnitude read from the header is stored and displayed in the new column ("Kepler magnitude" or "TESS magnitude" respectively); the "Quality" field was added to Kepler/TESS (the field already existed in the QLP plug-in).

So now the user may exclude any bad points, check for the median or mean using the "Descriptive statistics by series" plug-in, and shift the baseline with the "Magnitude baseline shifter" (one of the possible approaches).

I've attached a 
[TESS_Kepler_TESSQLP_examples.zip](https://github.com/AAVSO/VStar/files/10369054/TESS_Kepler_TESSQLP_examples.zip)
with samples.

![image](https://user-images.githubusercontent.com/44919945/211210439-2438e2d3-46c2-46e8-8c0b-9429c530362d.png)

