### PR TITLE
324 provide means to know the valid names for columns used in vela filter

### DIFF
--- a/src/org/aavso/tools/vstar/plugin/filter/impl/VeLaObservationFilterDialog.java
+++ b/src/org/aavso/tools/vstar/plugin/filter/impl/VeLaObservationFilterDialog.java
@@ -37,10 +37,8 @@ import javax.swing.JTextField;
 import org.aavso.tools.vstar.ui.dialog.AbstractOkCancelDialog;
 import org.aavso.tools.vstar.ui.dialog.MessageBox;
 import org.aavso.tools.vstar.ui.mediator.Mediator;
-import org.aavso.tools.vstar.ui.mediator.message.NewStarMessage;
 import org.aavso.tools.vstar.util.Pair;
 import org.aavso.tools.vstar.util.locale.LocaleProps;
-import org.aavso.tools.vstar.util.notification.Listener;
 import org.aavso.tools.vstar.vela.VeLaValidObservationEnvironment;
 
 /**
@@ -65,9 +63,6 @@ public class VeLaObservationFilterDialog extends AbstractOkCancelDialog {
 	 */
 	public VeLaObservationFilterDialog() {
 		super("Filter Observations");
-
-		Mediator.getInstance().getNewStarNotifier()
-				.addListener(createNewStarListener());
 
 		Container contentPane = this.getContentPane();
 
@@ -107,9 +102,11 @@ public class VeLaObservationFilterDialog extends AbstractOkCancelDialog {
 
 	@Override
 	public void showDialog() {
-		String defaultName = Mediator.getInstance().getDocumentManager()
-				.getNextUntitledFilterName();
+		String defaultName = Mediator.getInstance().getDocumentManager().getNextUntitledFilterName();
 		nameField.setText(defaultName);
+		String[] props = VeLaValidObservationEnvironment.symbols();
+		obsPropsList.setModel(new DefaultComboBoxModel<String>(props));
+
 		super.showDialog();
 	}
 
@@ -146,12 +143,8 @@ public class VeLaObservationFilterDialog extends AbstractOkCancelDialog {
 		panel.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
 
 		obsPropsList = new JComboBox<String>();
-		obsPropsList.setBorder(BorderFactory
-				.createTitledBorder("Observation Properties"));
+		obsPropsList.setBorder(BorderFactory.createTitledBorder("Observation Properties"));
 
-		String[] props = VeLaValidObservationEnvironment.symbols();
-		obsPropsList.setModel(new DefaultComboBoxModel<String>(props));
-		
 		obsPropsList.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -187,7 +180,8 @@ public class VeLaObservationFilterDialog extends AbstractOkCancelDialog {
 		JButton loadButton = new JButton(LocaleProps.get("LOAD_BUTTON"));
 		loadButton.addActionListener(e -> {
 			try {
-				Pair<String, String> content = Mediator.getInstance().getVelaFileLoadDialog().readFileAsString(this, null);
+				Pair<String, String> content = Mediator.getInstance().getVelaFileLoadDialog().readFileAsString(this,
+						null);
 				if (content != null) {
 					velaFilterField.setText(content.first);
 				}
@@ -222,25 +216,6 @@ public class VeLaObservationFilterDialog extends AbstractOkCancelDialog {
 		};
 	}
 
-	/**
-	 * @return A new star listener for the filter dialog.
-	 */
-	public Listener<NewStarMessage> createNewStarListener() {
-		return new Listener<NewStarMessage>() {
-
-			@Override
-			public void update(NewStarMessage info) {
-				velaFilterField.setText("");
-				String[] props = VeLaValidObservationEnvironment.symbols();
-				obsPropsList.setModel(new DefaultComboBoxModel<String>(props));
-			}
-
-			@Override
-			public boolean canBeRemoved() {
-				return false;
-			}
-		};
-	}
 
 	/**
 	 * @see org.aavso.tools.vstar.ui.dialog.AbstractOkCancelDialog#cancelAction()

--- a/src/org/aavso/tools/vstar/plugin/filter/impl/VeLaObservationFilterDialog.java
+++ b/src/org/aavso/tools/vstar/plugin/filter/impl/VeLaObservationFilterDialog.java
@@ -149,6 +149,9 @@ public class VeLaObservationFilterDialog extends AbstractOkCancelDialog {
 		obsPropsList.setBorder(BorderFactory
 				.createTitledBorder("Observation Properties"));
 
+		String[] props = VeLaValidObservationEnvironment.symbols();
+		obsPropsList.setModel(new DefaultComboBoxModel<String>(props));
+		
 		obsPropsList.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {

--- a/src/org/aavso/tools/vstar/ui/model/list/AAVSOFormatRawDataColumnInfoSource.java
+++ b/src/org/aavso/tools/vstar/ui/model/list/AAVSOFormatRawDataColumnInfoSource.java
@@ -17,6 +17,7 @@
  */
 package org.aavso.tools.vstar.ui.model.list;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,8 +28,7 @@ import org.aavso.tools.vstar.util.prefs.NumericPrecisionPrefs;
 /**
  * AAVSO format (file, database) raw data table column information source.
  */
-public class AAVSOFormatRawDataColumnInfoSource implements
-		ITableColumnInfoSource {
+public class AAVSOFormatRawDataColumnInfoSource implements ITableColumnInfoSource {
 
 	// Table columns.
 	private static final int TIME_COLUMN = 0;
@@ -123,21 +123,28 @@ public class AAVSOFormatRawDataColumnInfoSource implements
 	/**
 	 * Constructor.
 	 * 
-	 * @param useLineNumbers
-	 *            Should line numbers be used?
+	 * @param useLineNumbers Should line numbers be used?
 	 */
 	public AAVSOFormatRawDataColumnInfoSource(boolean useLineNumbers) {
 		this.useLineNumbers = useLineNumbers;
 	}
 
+	@Override
 	public int getColumnCount() {
 		return useLineNumbers ? LINE_NUM_COLUMN + 1 : LINE_NUM_COLUMN;
 	}
 
+	@Override
+	public Collection<String> getColumnNames() {
+		return COLUMN_NAMES.keySet();
+	}
+
+	@Override
 	public int getDiscrepantColumnIndex() {
 		return DISCREPANT_COLUMN;
 	}
 
+	@Override
 	public String getTableColumnTitle(int index) {
 		String columnName = null;
 
@@ -233,6 +240,7 @@ public class AAVSOFormatRawDataColumnInfoSource implements
 		return columnName;
 	}
 
+	@Override
 	public Class<?> getTableColumnClass(int index) {
 		Class<?> clazz = String.class;
 
@@ -300,25 +308,23 @@ public class AAVSOFormatRawDataColumnInfoSource implements
 		return clazz;
 	}
 
+	@Override
 	public Object getTableColumnValue(int index, ValidObservation ob) {
 		Object value = null;
 
 		switch (index) {
 		case TIME_COLUMN:
-			value = NumericPrecisionPrefs.formatTime(ob.getDateInfo()
-					.getJulianDay());
+			value = NumericPrecisionPrefs.formatTime(ob.getDateInfo().getJulianDay());
 			;
 			break;
 		case CALENDAR_DATE_COLUMN:
 			value = ob.getDateInfo().getCalendarDate();
 			break;
 		case MAGNITUDE_COLUMN:
-			value = NumericPrecisionPrefs.formatMag(ob.getMagnitude()
-					.getMagValue());
+			value = NumericPrecisionPrefs.formatMag(ob.getMagnitude().getMagValue());
 			break;
 		case UNCERTAINTY_COLUMN:
-			value = NumericPrecisionPrefs.formatMag(ob.getMagnitude()
-					.getUncertainty());
+			value = NumericPrecisionPrefs.formatMag(ob.getMagnitude().getUncertainty());
 			break;
 		case BAND_COLUMN:
 			value = ob.getBand().getDescription();
@@ -327,8 +333,7 @@ public class AAVSOFormatRawDataColumnInfoSource implements
 			value = ob.getObsCode();
 			break;
 		case VALFLAG_COLUMN:
-			value = ob.getValidationType() == null ? "" : ob
-					.getValidationType().toString();
+			value = ob.getValidationType() == null ? "" : ob.getValidationType().toString();
 			break;
 		case COMP_STAR_1_COLUMN:
 			value = ob.getCompStar1();
@@ -340,8 +345,7 @@ public class AAVSOFormatRawDataColumnInfoSource implements
 			value = ob.getCharts();
 			break;
 		case COMMENT_CODE_COLUMN:
-			value = ob.getCommentCode() == null ? "" : ob.getCommentCode()
-					.getOrigString();
+			value = ob.getCommentCode() == null ? "" : ob.getCommentCode().getOrigString();
 			break;
 		case COMMENTS_COLUMN:
 			value = ob.getComments();
@@ -359,13 +363,11 @@ public class AAVSOFormatRawDataColumnInfoSource implements
 			value = ob.getKMag();
 			break;
 		case HJD_COLUMN:
-			value = ob.getHJD() == null ? "" : NumericPrecisionPrefs
-					.formatTime(ob.getHJD().getJulianDay());
+			value = ob.getHJD() == null ? "" : NumericPrecisionPrefs.formatTime(ob.getHJD().getJulianDay());
 			break;
 		case HQ_UNCERTAINTY_COLUMN:
 			Double hqUncertainty = ob.getHqUncertainty();
-			value = null == hqUncertainty ? "" : NumericPrecisionPrefs
-					.formatMag(ob.getHqUncertainty());
+			value = null == hqUncertainty ? "" : NumericPrecisionPrefs.formatMag(ob.getHqUncertainty());
 			break;
 		case MTYPE_COLUMN:
 			value = ob.getMType() == null ? "" : ob.getMType().toString();
@@ -402,8 +404,7 @@ public class AAVSOFormatRawDataColumnInfoSource implements
 	}
 
 	@Override
-	public int getColumnIndexByName(String name)
-			throws IllegalArgumentException {
+	public int getColumnIndexByName(String name) throws IllegalArgumentException {
 		if (name == null || !COLUMN_NAMES.containsKey(name)) {
 			throw new IllegalArgumentException("No column name: " + name);
 		} else {

--- a/src/org/aavso/tools/vstar/ui/model/list/ArbitraryFormatPhasePlotColumnInfoSource.java
+++ b/src/org/aavso/tools/vstar/ui/model/list/ArbitraryFormatPhasePlotColumnInfoSource.java
@@ -38,14 +38,17 @@ public class ArbitraryFormatPhasePlotColumnInfoSource extends
 		COLUMN_NAMES.put(PHASE_COLUMN_NAME, PHASE_COLUMN);
 	}
 
+	@Override
 	public int getColumnCount() {
 		return super.getColumnCount() + 1;
 	}
 
+	@Override
 	public int getDiscrepantColumnIndex() {
 		return super.getDiscrepantColumnIndex() + 1;
 	}
 
+	@Override
 	public String getTableColumnTitle(int index) {
 		String columnName = null;
 
@@ -61,6 +64,7 @@ public class ArbitraryFormatPhasePlotColumnInfoSource extends
 		return columnName;
 	}
 
+	@Override
 	public Class<?> getTableColumnClass(int index) {
 		Class<?> clazz = null;
 
@@ -76,6 +80,7 @@ public class ArbitraryFormatPhasePlotColumnInfoSource extends
 		return clazz;
 	}
 
+	@Override
 	public Object getTableColumnValue(int index, ValidObservation ob) {
 		Object value = null;
 

--- a/src/org/aavso/tools/vstar/ui/model/list/ArbitraryFormatRawDataColumnInfoSource.java
+++ b/src/org/aavso/tools/vstar/ui/model/list/ArbitraryFormatRawDataColumnInfoSource.java
@@ -17,6 +17,7 @@
  */
 package org.aavso.tools.vstar.ui.model.list;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -60,15 +61,23 @@ public class ArbitraryFormatRawDataColumnInfoSource implements
 		COLUMN_NAMES.put(DISCREPANT_COLUMN_NAME, DISCREPANT_COLUMN);
 	}
 
+	@Override
 	public int getColumnCount() {
 		int detailCount = ValidObservation.getDetailTitles().size();
 		return DISCREPANT_COLUMN + detailCount + 1;
 	}
 
+	@Override
+	public Collection<String> getColumnNames() {
+		return COLUMN_NAMES.keySet();
+	}
+
+	@Override
 	public int getDiscrepantColumnIndex() {
 		return DISCREPANT_COLUMN;
 	}
 
+	@Override
 	public String getTableColumnTitle(int index) {
 		String columnName = null;
 
@@ -104,6 +113,7 @@ public class ArbitraryFormatRawDataColumnInfoSource implements
 		return columnName;
 	}
 
+	@Override
 	public Class<?> getTableColumnClass(int index) {
 		Class<?> clazz = String.class;
 
@@ -129,6 +139,7 @@ public class ArbitraryFormatRawDataColumnInfoSource implements
 		return clazz;
 	}
 
+	@Override
 	public Object getTableColumnValue(int index, ValidObservation ob) {
 		Object value = null;
 

--- a/src/org/aavso/tools/vstar/ui/model/list/ITableColumnInfoSource.java
+++ b/src/org/aavso/tools/vstar/ui/model/list/ITableColumnInfoSource.java
@@ -17,6 +17,8 @@
  */
 package org.aavso.tools.vstar.ui.model.list;
 
+import java.util.Collection;
+
 import org.aavso.tools.vstar.data.ValidObservation;
 
 /**
@@ -32,6 +34,13 @@ public interface ITableColumnInfoSource {
 	 * @return The column count.
 	 */
 	abstract public int getColumnCount();
+	
+	/**
+	 * Return the names of the table columns for this source.
+	 * 
+	 * @return The column names.
+	 */
+	abstract public Collection<String> getColumnNames();
 	
 	/**
 	 * Return the index of the "is-discrepant" column.

--- a/src/org/aavso/tools/vstar/ui/model/list/SimpleFormatRawDataColumnInfoSource.java
+++ b/src/org/aavso/tools/vstar/ui/model/list/SimpleFormatRawDataColumnInfoSource.java
@@ -17,6 +17,7 @@
  */
 package org.aavso.tools.vstar.ui.model.list;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -59,14 +60,22 @@ public class SimpleFormatRawDataColumnInfoSource implements
 		COLUMN_NAMES.put(DISCREPANT_COLUMN_NAME, DISCREPANT_COLUMN);
 	}
 
+	@Override
 	public int getColumnCount() {
 		return DISCREPANT_COLUMN + 1;
 	}
 
+	@Override
+	public Collection<String> getColumnNames() {
+		return COLUMN_NAMES.keySet();
+	}
+
+	@Override
 	public int getDiscrepantColumnIndex() {
 		return DISCREPANT_COLUMN;
 	}
 
+	@Override
 	public String getTableColumnTitle(int index) {
 		String columnName = null;
 
@@ -97,6 +106,7 @@ public class SimpleFormatRawDataColumnInfoSource implements
 		return columnName;
 	}
 
+	@Override
 	public Class<?> getTableColumnClass(int index) {
 		Class<?> clazz = String.class;
 
@@ -122,6 +132,7 @@ public class SimpleFormatRawDataColumnInfoSource implements
 		return clazz;
 	}
 
+	@Override
 	public Object getTableColumnValue(int index, ValidObservation ob) {
 		Object value = null;
 

--- a/src/org/aavso/tools/vstar/vela/VeLaValidObservationEnvironment.java
+++ b/src/org/aavso/tools/vstar/vela/VeLaValidObservationEnvironment.java
@@ -89,11 +89,6 @@ public class VeLaValidObservationEnvironment extends VeLaEnvironment<Operand> {
 				operand = operand(name, ob.getPreviousCyclePhase());
 			}
 		} else {
-//			contained = ob.nonEmptyDetailExists(name);
-//
-//			if (contained) {
-//				operand = operand(name, ob.getDetail(name));
-//			}
 			if (columnInfoSource != null) {
 				int index = columnInfoSource.getColumnIndexByName(name);
 				operand = objToOperand(name, columnInfoSource.getTableColumnValue(index, ob));
@@ -218,26 +213,6 @@ public class VeLaValidObservationEnvironment extends VeLaEnvironment<Operand> {
 
 			if (columnInfoSource != null) {
 				Collection<String> columnNames = columnInfoSource.getColumnNames();
-
-//		symbol2CanonicalSymbol.put("COMMENTCODES", "COMMENTCODES");
-//
-				// ** add these two back here and above **
-//		symbol2CanonicalSymbol.put("OBSCODE", "OBS_CODE");
-//
-//		symbol2CanonicalSymbol.put("OBS_TYPE", "OBSTYPE");
-//
-//		symbol2CanonicalSymbol.put("COMPSTAR1", "COMP_STAR1");
-//
-//		symbol2CanonicalSymbol.put("COMPSTAR2", "COMP_STAR2");
-//
-//		symbol2CanonicalSymbol.put("VALFLAG", "VALFLAG");
-//
-//		symbol2CanonicalSymbol.put("MTYPE", "MTYPE");
-//		symbol2CanonicalSymbol.put("TRANSFORMED", "TRANSFORMED");
-
-//		Set<String> detailTitles = ValidObservation.getDetailTitles().keySet();
-//		Set<String> detailTitles = ValidObservation.getDetailTitles().keySet().stream().map(name -> name.toUpperCase())
-//				.collect(Collectors.toSet());
 
 				for (String columnName : columnNames) {
 					if (columnName != null) {

--- a/src/org/aavso/tools/vstar/vela/VeLaValidObservationEnvironment.java
+++ b/src/org/aavso/tools/vstar/vela/VeLaValidObservationEnvironment.java
@@ -225,7 +225,7 @@ public class VeLaValidObservationEnvironment extends VeLaEnvironment<Operand> {
 		symbol2CanonicalSymbol.put("TRANSFORMED", "TRANSFORMED");
 
 		for (String detailKey : ValidObservation.getDetailTitles().keySet()) {
-			if (!detailKey.contains("_") && detailKey != null) {
+			if (detailKey != null && !detailKey.contains("_")) {
 				symbol2CanonicalSymbol.put(detailKey, detailKey);
 			}
 		}

--- a/src/org/aavso/tools/vstar/vela/VeLaValidObservationEnvironment.java
+++ b/src/org/aavso/tools/vstar/vela/VeLaValidObservationEnvironment.java
@@ -17,12 +17,18 @@
  */
 package org.aavso.tools.vstar.vela;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
 
 import org.aavso.tools.vstar.data.ValidObservation;
+import org.aavso.tools.vstar.ui.mediator.AnalysisType;
+import org.aavso.tools.vstar.ui.mediator.Mediator;
+import org.aavso.tools.vstar.ui.mediator.NewStarType;
+import org.aavso.tools.vstar.ui.mediator.message.NewStarMessage;
+import org.aavso.tools.vstar.ui.model.list.ITableColumnInfoSource;
 
 /**
  * A VeLa environment that is backed by a ValidObservation instance.
@@ -34,6 +40,8 @@ public class VeLaValidObservationEnvironment extends VeLaEnvironment<Operand> {
 	static {
 		symbol2CanonicalSymbol = new TreeMap<String, String>();
 	}
+
+	private static ITableColumnInfoSource columnInfoSource = null;
 
 	private ValidObservation ob;
 
@@ -68,6 +76,8 @@ public class VeLaValidObservationEnvironment extends VeLaEnvironment<Operand> {
 			operand = operand(name, ob.getBand().getShortName());
 		} else if ("SERIES".equals(name)) {
 			operand = operand(name, ob.getSeries().getDescription());
+		} else if ("OBS_CODE".equals(name)) {
+			operand = operand(name, ob.getObsCode());
 		} else if ("STANDARDPHASE".equals(name)) {
 			contained &= ob.getStandardPhase() != null;
 			if (contained) {
@@ -78,38 +88,22 @@ public class VeLaValidObservationEnvironment extends VeLaEnvironment<Operand> {
 			if (contained) {
 				operand = operand(name, ob.getPreviousCyclePhase());
 			}
-		} else if ("MTYPE".equals(name)) {
-			operand = operand(name, ob.getMType().getShortName());
-		} else if ("OBSTYPE".equals(name)) {
-			operand = operand(name, ob.getObsType());
-		} else if ("VALFLAG".equals(name)) {
-			contained &= ob.getValidationType() != null;
-			if (contained) {
-				operand = operand(name, ob.getValidationType().getValflag());
-			}
-		} else if ("TRANSFORMED".equals(name)) {
-			operand = operand(name, ob.isTransformed());
-		} else if ("COMMENTCODES".equals(name)) {
-			contained &= ob.getCommentCode() != null;
-			if (contained) {
-				operand = operand(name, ob.getCommentCode().getOrigString());
-			}
 		} else {
-			contained = ob.nonEmptyDetailExists(name);
-
-			if (contained) {
-				operand = operand(name, ob.getDetail(name));
+//			contained = ob.nonEmptyDetailExists(name);
+//
+//			if (contained) {
+//				operand = operand(name, ob.getDetail(name));
+//			}
+			if (columnInfoSource != null) {
+				int index = columnInfoSource.getColumnIndexByName(name);
+				operand = objToOperand(name, columnInfoSource.getTableColumnValue(index, ob));
 			}
 		}
 
-		// TODO:
-		// - discrepant, excluded, fainter-than: for model creation, later
-		// - HJD later
-
 		return Optional.ofNullable(operand);
 	}
-	
-	// Cached operand creation methods.
+
+	// Cached operand creation methods
 
 	protected Operand operand(String name, Integer value) {
 		return operand(Type.INTEGER, name, value);
@@ -127,13 +121,29 @@ public class VeLaValidObservationEnvironment extends VeLaEnvironment<Operand> {
 		return operand(Type.BOOLEAN, name, value);
 	}
 
+	protected Operand objToOperand(String name, Object value) {
+		Type type = Type.NONE;
+
+		if (value instanceof Integer) {
+			type = Type.INTEGER;
+		} else if (value instanceof Double) {
+			type = Type.REAL;
+		} else if (value instanceof String) {
+			type = Type.STRING;
+		} else if (value instanceof Boolean) {
+			type = Type.BOOLEAN;
+		}
+
+		return operand(type, name, value);
+	}
+
 	// Common operand factory method
 
 	protected Operand operand(Type type, String name, Object value) {
 		Operand operand = null;
 
 		name = name.toUpperCase();
-		
+
 		if (cache.containsKey(name)) {
 			operand = cache.get(name);
 		} else {
@@ -163,13 +173,12 @@ public class VeLaValidObservationEnvironment extends VeLaEnvironment<Operand> {
 	/**
 	 * Return the symbols associated with currently loaded observations.
 	 * 
-	 * @param info
-	 *            A new star information message.
+	 * @param info A new star information message.
 	 * @return An array of symbol names.
 	 */
 	public static String[] symbols() {
 		reset();
-		
+
 		String[] symbols = new String[symbol2CanonicalSymbol.size()];
 		int i = 0;
 		for (String symbol : symbol2CanonicalSymbol.keySet()) {
@@ -191,6 +200,55 @@ public class VeLaValidObservationEnvironment extends VeLaEnvironment<Operand> {
 	private static void populateMap() {
 		symbol2CanonicalSymbol.clear();
 
+		// Use current observation list column names as VeLa variables
+
+		Mediator mediator = Mediator.getInstance();
+		NewStarMessage newStarMsg = mediator.getLatestNewStarMessage();
+		AnalysisType analysisType = mediator.getAnalysisType();
+
+		if (newStarMsg != null) {
+
+			NewStarType newStarType = newStarMsg.getNewStarType();
+
+			if (analysisType == AnalysisType.RAW_DATA) {
+				columnInfoSource = newStarType.getRawDataTableColumnInfoSource();
+			} else {
+				columnInfoSource = newStarType.getPhasePlotTableColumnInfoSource();
+			}
+
+			if (columnInfoSource != null) {
+				Collection<String> columnNames = columnInfoSource.getColumnNames();
+
+//		symbol2CanonicalSymbol.put("COMMENTCODES", "COMMENTCODES");
+//
+				// ** add these two back here and above **
+//		symbol2CanonicalSymbol.put("OBSCODE", "OBS_CODE");
+//
+//		symbol2CanonicalSymbol.put("OBS_TYPE", "OBSTYPE");
+//
+//		symbol2CanonicalSymbol.put("COMPSTAR1", "COMP_STAR1");
+//
+//		symbol2CanonicalSymbol.put("COMPSTAR2", "COMP_STAR2");
+//
+//		symbol2CanonicalSymbol.put("VALFLAG", "VALFLAG");
+//
+//		symbol2CanonicalSymbol.put("MTYPE", "MTYPE");
+//		symbol2CanonicalSymbol.put("TRANSFORMED", "TRANSFORMED");
+
+//		Set<String> detailTitles = ValidObservation.getDetailTitles().keySet();
+//		Set<String> detailTitles = ValidObservation.getDetailTitles().keySet().stream().map(name -> name.toUpperCase())
+//				.collect(Collectors.toSet());
+
+				for (String columnName : columnNames) {
+					if (columnName != null) {
+						String velaName = columnName.replace(" ", "_");
+						symbol2CanonicalSymbol.put(velaName.toUpperCase(), columnName);
+					}
+				}
+			}
+		}
+		// Add common variables
+
 		symbol2CanonicalSymbol.put("TIME", "TIME");
 		symbol2CanonicalSymbol.put("T", "TIME");
 		symbol2CanonicalSymbol.put("JD", "TIME");
@@ -204,30 +262,15 @@ public class VeLaValidObservationEnvironment extends VeLaEnvironment<Operand> {
 		symbol2CanonicalSymbol.put("BAND", "BAND");
 		symbol2CanonicalSymbol.put("SERIES", "SERIES");
 		symbol2CanonicalSymbol.put("SHORTBAND", "SHORTBAND");
-
-		symbol2CanonicalSymbol.put("STANDARDPHASE", "STANDARDPHASE");
-		symbol2CanonicalSymbol.put("PHASE", "STANDARDPHASE");
-		symbol2CanonicalSymbol.put("PREVIOUSCYCLEPHASE", "PREVIOUSCYCLEPHASE");
-
-		symbol2CanonicalSymbol.put("COMMENTCODES", "COMMENTCODES");
-
+		
 		symbol2CanonicalSymbol.put("OBSCODE", "OBS_CODE");
 
-		symbol2CanonicalSymbol.put("OBS_TYPE", "OBSTYPE");
+		// Add phase variables if we're in phase plot mode
 
-		symbol2CanonicalSymbol.put("COMPSTAR1", "COMP_STAR1");
-		
-		symbol2CanonicalSymbol.put("COMPSTAR2", "COMP_STAR2");
-
-		symbol2CanonicalSymbol.put("VALFLAG", "VALFLAG");
-
-		symbol2CanonicalSymbol.put("MTYPE", "MTYPE");
-		symbol2CanonicalSymbol.put("TRANSFORMED", "TRANSFORMED");
-
-		for (String detailKey : ValidObservation.getDetailTitles().keySet()) {
-			if (detailKey != null && !detailKey.contains("_")) {
-				symbol2CanonicalSymbol.put(detailKey, detailKey);
-			}
+		if (analysisType == AnalysisType.PHASE_PLOT) {
+			symbol2CanonicalSymbol.put("STANDARDPHASE", "STANDARDPHASE");
+			symbol2CanonicalSymbol.put("PHASE", "STANDARDPHASE");
+			symbol2CanonicalSymbol.put("PREVIOUSCYCLEPHASE", "PREVIOUSCYCLEPHASE");
 		}
 	}
 }

--- a/test/org/aavso/tools/vstar/vela/VeLaTest.java
+++ b/test/org/aavso/tools/vstar/vela/VeLaTest.java
@@ -1289,26 +1289,39 @@ public class VeLaTest extends TestCase {
 
 	// Filter test cases
 
-	public void testVeLaBooleanExpressionsAsFilters() {
+	public void testVeLaBooleanExpressionsAsFilters1() {
 		List<ValidObservation> obs = commonObs();
-		String expr;
-
-		expr = "uncertainty >= 0.1";
+		String expr = "uncertainty >= 0.1";
 		assertEquals(2, filterObs(expr, obs).size());
+	}
 
-		expr = "uncertainty > 0.01 and uncertainty < 0.03";
+	public void testVeLaBooleanExpressionsAsFilters2() {
+		List<ValidObservation> obs = commonObs();
+		String expr = "uncertainty > 0.01 and uncertainty < 0.03";
 		assertEquals(1, filterObs(expr, obs).size());
+	}
 
-		expr = "magnitude > 12 and (uncertainty > 0 and uncertainty <= 0.01)";
+	public void testVeLaBooleanExpressionsAsFilters3() {
+		List<ValidObservation> obs = commonObs();
+		String expr = "magnitude > 12 and (uncertainty > 0 and uncertainty <= 0.01)";
 		assertEquals(1, filterObs(expr, obs).size());
+	}
 
-		expr = "obscode = \"PEX\"";
+	public void testVeLaBooleanExpressionsAsFilters4() {
+		List<ValidObservation> obs = commonObs();
+		String expr = "obs_code = \"PEX\"";
 		assertEquals(1, filterObs(expr, obs).size());
+	}
 
-		expr = "mag > 6 and mag < 15 and obscode = \"PEX\"";
+	public void testVeLaBooleanExpressionsAsFilters5() {
+		List<ValidObservation> obs = commonObs();
+		String expr = "mag > 6 and mag < 15 and obs_code = \"PEX\"";
 		assertEquals(1, filterObs(expr, obs).size());
+	}
 
-		expr = "mag > 6 and mag < 15 and obscode in [\"PEX\" \"PLA\"]";
+	public void testVeLaBooleanExpressionsAsFilters6() {
+		List<ValidObservation> obs = commonObs();
+		String expr = "mag > 6 and mag < 15 and obs_code in [\"PEX\" \"PLA\"]";
 		assertEquals(2, filterObs(expr, obs).size());
 	}
 


### PR DESCRIPTION
I've addressed this @orionlee. Essentially, the observation list column names are the source for VeLa filter columns, along with some additional aliases (e.g. jd, time, t, mag, magnitude) and some context sensitive names (*phase).

The VeLa filter drop-down menu of names reflects these.

@mpyat2: you may be interested to look at this.