### PR TITLE
TESS-related plug-ins optimization

### DIFF
--- a/plugin/build.xml
+++ b/plugin/build.xml
@@ -18,17 +18,17 @@
 	<property name="vstar_plugins_zip_dir" location="vstar-plugins" />
 	<property name="plugins_list_file" value=".plugins.lst" />
 
-   <target name="init">
-        <!-- Create the time stamp -->
-        <tstamp />
+	<target name="init">
+		<!-- Create the time stamp -->
+		<tstamp />
 
-        <!-- Create the build directory structure used by compile and test. -->
-        <mkdir dir="${build}" />
-        <mkdir dir="${dist}" />
+		<!-- Create the build directory structure used by compile and test. -->
+		<mkdir dir="${build}" />
+		<mkdir dir="${dist}" />
 		<mkdir dir="${dist_lib}" />
-        <mkdir dir="${test_build}" />
-        <mkdir dir="${test_report}" />
-    </target>
+		<mkdir dir="${test_build}" />
+		<mkdir dir="${test_report}" />
+	</target>
 
 	<target name="compile" depends="init" description="compile the source ">
 		<path id="libs">
@@ -49,8 +49,8 @@
 		<mkdir dir="${dist_lib}" />
 
 		<!-- I don't like the idea of forcing people to install and use ant.contrib
-         so right now this is just a huge list of targets add your new plugin here
-	     as another jar task line (comment by Adam Weber)-->
+		so right now this is just a huge list of targets add your new plugin here
+		as another jar task line (comment by Adam Weber)-->
 		<jar jarfile="${dist}/${pkg}.AAVSOnetEpochPhotometryObservationSource.jar" basedir="${build.classes}" includes="**/AAVSOnetEpochPhotometryObservationSource**.class" />
 		<jar jarfile="${dist}/${pkg}.AAVSOUploadFileFormatObservationSource.jar" basedir="${build.classes}" includes="**/AAVSOUploadFileFormatObservationSource**.class" />
 		<jar jarfile="${dist}/${pkg}.AoVPeriodSearch.jar" basedir="${build.classes}" includes="**/AoVPeriodSearch**.class" />
@@ -70,9 +70,6 @@
 		<jar jarfile="${dist}/${pkg}.HJDConverter.jar" basedir="${build.classes}" includes="**/HJDConverter**.class" />
 		<jar jarfile="${dist}/${pkg}.HipparcosObservationSource.jar" basedir="${build.classes}" includes="**/HipparcosObservationSource**.class" />
 		<jar jarfile="${dist}/${pkg}.JDToDateTool.jar" basedir="${build.classes}" includes="**/JDToDateTool**.class" />
-		<jar jarfile="${dist}/${pkg}.KeplerFITSObservationSource.jar" basedir="${build.classes}" includes="**/KeplerFITSObservationSource**.class" />
-        <jar jarfile="${dist}/${pkg}.LightKurveFITSObservationSource.jar" basedir="${build.classes}" includes="**/LightKurveFITSObservationSource**.class" />
-		<jar jarfile="${dist}/${pkg}.QLPFITSObservationSource.jar" basedir="${build.classes}" includes="**/QLPFITSObservationSource**.class" />
 		<jar jarfile="${dist}/${pkg}.MagnitudeBaselineShifter.jar" basedir="${build.classes}" includes="**/MagnitudeBaselineShifter**.class" />
 		<jar jarfile="${dist}/${pkg}.MeanTimeBetweenSelectionTool.jar" basedir="${build.classes}" includes="**/MeanTimeBetweenSelectionTool**.class" />
 		<jar jarfile="${dist}/${pkg}.NSVSObservationSource.jar" basedir="${build.classes}" includes="**/NSVSObservationSource**.class" />
@@ -87,6 +84,10 @@
 		<jar jarfile="${dist}/${pkg}.GAIADR2XformObSource.jar" basedir="${build.classes}" includes="**/GAIADR2XformObSource**.class" />
 		<jar jarfile="${dist}/${pkg}.GAIADR2XformFileObSource.jar" basedir="${build.classes}" includes="**/GAIADR2XformFileObSource**.class" />		
 		<jar jarfile="${dist_lib}/${pkg_lib}.GaiaObSourceBase.jar" basedir="${build.classes}" includes="**/GaiaObSourceBase**.class" />						
+		<jar jarfile="${dist}/${pkg}.KeplerFITSObservationSource.jar" basedir="${build.classes}" includes="**/KeplerFITSObservationSource**.class" />
+		<jar jarfile="${dist}/${pkg}.LightKurveFITSObservationSource.jar" basedir="${build.classes}" includes="**/LightKurveFITSObservationSource**.class" />
+		<jar jarfile="${dist}/${pkg}.QLPFITSObservationSource.jar" basedir="${build.classes}" includes="**/QLPFITSObservationSource**.class" />
+		<jar jarfile="${dist_lib}/${pkg_lib}.TESSObservationRetrieverBase.jar" basedir="${build.classes}" includes="**/TESSObservationRetrieverBase**.class" />						
 		<!--
 		<jar jarfile="${dist}/${pkg}.DifferentialPhotometry.jar" basedir="${build.classes}" includes="**/DifferentialPhotometry**.class" />
 		<jar jarfile="${dist}/${pkg}.IRISAutomaticPhotometryObservationSource.jar" basedir="${build.classes}" includes="**/IRISAutomaticPhotometryObservationSource**.class" />
@@ -206,9 +207,6 @@
 		<copy file="${dist}/${pkg}.HJDConverter.jar" todir="${vstar_plugins_zip_dir}/${plugin_dir}" overwrite="true" />
 		<copy file="${dist}/${pkg}.HipparcosObservationSource.jar" todir="${vstar_plugins_zip_dir}/${plugin_dir}" overwrite="true" />
 		<copy file="${dist}/${pkg}.JDToDateTool.jar" todir="${vstar_plugins_zip_dir}/${plugin_dir}" overwrite="true" />
-		<copy file="${dist}/${pkg}.KeplerFITSObservationSource.jar" todir="${vstar_plugins_zip_dir}/${plugin_dir}" overwrite="true" />
-        <copy file="${dist}/${pkg}.LightKurveFITSObservationSource.jar" todir="${vstar_plugins_zip_dir}/${plugin_dir}" overwrite="true" />
-		<copy file="${dist}/${pkg}.QLPFITSObservationSource.jar" todir="${vstar_plugins_zip_dir}/${plugin_dir}" overwrite="true" />
 		<copy file="${dist}/${pkg}.MagnitudeBaselineShifter.jar" todir="${vstar_plugins_zip_dir}/${plugin_dir}" overwrite="true" />
 		<copy file="${dist}/${pkg}.MeanTimeBetweenSelectionTool.jar" todir="${vstar_plugins_zip_dir}/${plugin_dir}" overwrite="true" />
 		<copy file="${dist}/${pkg}.NSVSObservationSource.jar" todir="${vstar_plugins_zip_dir}/${plugin_dir}" overwrite="true" />
@@ -221,9 +219,13 @@
 		<copy file="${dist}/${pkg}.JulianDateObservationsFilter.jar" todir="${vstar_plugins_zip_dir}/${plugin_dir}" overwrite="true" />
 		<copy file="${dist}/${pkg}.ZTFObSource.jar" todir="${vstar_plugins_zip_dir}/${plugin_dir}" overwrite="true" />
 		<copy file="${dist}/${pkg}.GAIADR2XformObSource.jar" todir="${vstar_plugins_zip_dir}/${plugin_dir}" overwrite="true" />
-		<copy file="${dist}/${pkg}.GAIADR2XformFileObSource.jar" todir="${vstar_plugins_zip_dir}/${plugin_dir}" overwrite="true" />		
-		<copy file="${dist_lib}/${pkg_lib}.GaiaObSourceBase.jar" todir="${vstar_plugins_zip_dir}/${plugin_lib_dir}" overwrite="true" />								
-		<!--		
+		<copy file="${dist}/${pkg}.GAIADR2XformFileObSource.jar" todir="${vstar_plugins_zip_dir}/${plugin_dir}" overwrite="true" />
+		<copy file="${dist_lib}/${pkg_lib}.GaiaObSourceBase.jar" todir="${vstar_plugins_zip_dir}/${plugin_lib_dir}" overwrite="true" />
+		<copy file="${dist}/${pkg}.KeplerFITSObservationSource.jar" todir="${vstar_plugins_zip_dir}/${plugin_dir}" overwrite="true" />
+		<copy file="${dist}/${pkg}.LightKurveFITSObservationSource.jar" todir="${vstar_plugins_zip_dir}/${plugin_dir}" overwrite="true" />
+		<copy file="${dist}/${pkg}.QLPFITSObservationSource.jar" todir="${vstar_plugins_zip_dir}/${plugin_dir}" overwrite="true" />
+		<copy file="${dist_lib}/${pkg_lib}.TESSObservationRetrieverBase.jar" todir="${vstar_plugins_zip_dir}/${plugin_lib_dir}" overwrite="true" />
+		<!--
 		<copy file="${dist}/${pkg}.DifferentialPhotometry.jar" todir="${vstar_plugins_zip_dir}/${plugin_dir}" overwrite="true" />
 		<copy file="${dist}/${pkg}.IRISAutomaticPhotometryObservationSource.jar" todir="${vstar_plugins_zip_dir}/${plugin_dir}" overwrite="true" />
 		<copy file="${dist}/${pkg}.MinimumScatterPeriodFinder.jar" todir="${vstar_plugins_zip_dir}/${plugin_dir}" overwrite="true" />
@@ -231,6 +233,7 @@
 		-->
 		<copy file="lib/tamfits.jar" todir="${vstar_plugins_zip_dir}/${plugin_lib_dir}" />
 
+		<delete file="${plugins_list_file}" />
 		<echo file="${plugins_list_file}" message="${pkg}.AAVSOnetEpochPhotometryObservationSource.jar${line.separator}" append="true" />
 		<echo file="${plugins_list_file}" message="${pkg}.AAVSOUploadFileFormatObservationSource.jar${line.separator}" append="true" />
 		<echo file="${plugins_list_file}" message="${pkg}.AoVPeriodSearch.jar${line.separator}" append="true" />
@@ -250,9 +253,6 @@
 		<echo file="${plugins_list_file}" message="${pkg}.HJDConverter.jar${line.separator}" append="true" />
 		<echo file="${plugins_list_file}" message="${pkg}.HipparcosObservationSource.jar${line.separator}" append="true" />
 		<echo file="${plugins_list_file}" message="${pkg}.JDToDateTool.jar${line.separator}" append="true" />
-		<echo file="${plugins_list_file}" message="${pkg}.KeplerFITSObservationSource.jar => tamfits.jar${line.separator}" append="true" />
-        <echo file="${plugins_list_file}" message="${pkg}.LightKurveFITSObservationSource.jar => tamfits.jar${line.separator}" append="true" />
-		<echo file="${plugins_list_file}" message="${pkg}.QLPFITSObservationSource.jar => tamfits.jar${line.separator}" append="true" />
 		<echo file="${plugins_list_file}" message="${pkg}.MagnitudeBaselineShifter.jar${line.separator}" append="true" />
 		<echo file="${plugins_list_file}" message="${pkg}.MeanTimeBetweenSelectionTool.jar${line.separator}" append="true" />
 		<echo file="${plugins_list_file}" message="${pkg}.NSVSObservationSource.jar${line.separator}" append="true" />
@@ -266,6 +266,9 @@
 		<echo file="${plugins_list_file}" message="${pkg}.ZTFObSource.jar${line.separator}" append="true" />
 		<echo file="${plugins_list_file}" message="${pkg}.GAIADR2XformObSource.jar => ${pkg_lib}.GaiaObSourceBase.jar ${line.separator}" append="true" />
 		<echo file="${plugins_list_file}" message="${pkg}.GAIADR2XformFileObSource.jar => ${pkg_lib}.GaiaObSourceBase.jar ${line.separator}" append="true" />		
+		<echo file="${plugins_list_file}" message="${pkg}.KeplerFITSObservationSource.jar => tamfits.jar,org.aavso.tools.vstar.external.lib.TESSObservationRetrieverBase.jar${line.separator}" append="true" />
+		<echo file="${plugins_list_file}" message="${pkg}.LightKurveFITSObservationSource.jar => tamfits.jar,org.aavso.tools.vstar.external.lib.TESSObservationRetrieverBase.jar${line.separator}" append="true" />
+		<echo file="${plugins_list_file}" message="${pkg}.QLPFITSObservationSource.jar => tamfits.jar,org.aavso.tools.vstar.external.lib.TESSObservationRetrieverBase.jar${line.separator}" append="true" />
 		<!--
 		<echo file="${plugins_list_file}" message="${pkg}.DifferentialPhotometry.jar${line.separator}" append="true" />
 		<echo file="${plugins_list_file}" message="${pkg}.IRISAutomaticPhotometryObservationSource.jar${line.separator}" append="true" />

--- a/plugin/src/org/aavso/tools/vstar/external/lib/TESSObservationRetrieverBase.java
+++ b/plugin/src/org/aavso/tools/vstar/external/lib/TESSObservationRetrieverBase.java
@@ -1,0 +1,328 @@
+/**
+ * VStar: a statistical analysis tool for variable star data.
+ * Copyright (C) 2009  AAVSO (http://www.aavso.org/)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed inputStream the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ */
+
+/**
+ *
+ * Based on C. Kotnik's and PMAK's KeplerFITSObservationSource code
+ * 2018-2023
+ * 
+*/
+
+package org.aavso.tools.vstar.external.lib;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import org.aavso.tools.vstar.data.DateInfo;
+import org.aavso.tools.vstar.data.InvalidObservation;
+import org.aavso.tools.vstar.data.Magnitude;
+import org.aavso.tools.vstar.data.SeriesType;
+import org.aavso.tools.vstar.data.ValidObservation;
+import org.aavso.tools.vstar.data.ValidObservation.JDflavour;
+import org.aavso.tools.vstar.exception.ObservationReadError;
+import org.aavso.tools.vstar.input.AbstractObservationRetriever;
+import org.aavso.tools.vstar.plugin.ObservationSourcePluginBase;
+import org.aavso.tools.vstar.ui.mediator.StarInfo;
+import org.aavso.tools.vstar.util.prefs.NumericPrecisionPrefs;
+import org.apache.commons.math.stat.descriptive.rank.Median;
+
+import nom.tam.fits.BasicHDU;
+import nom.tam.fits.BinaryTableHDU;
+import nom.tam.fits.Fits;
+import nom.tam.fits.FitsException;
+import nom.tam.fits.ImageHDU;
+
+public abstract class TESSObservationRetrieverBase extends AbstractObservationRetriever {
+
+	public static final double INVALID_MAG = 99.99;
+	
+	public enum BinaryTableFieldType {
+		UNKNOWN,
+		TIME,
+		FLUX,
+		FLUX_ERROR,
+		QUALITY_FLAGS
+	}
+	
+	public class ObservationReadErrorFITS extends Exception {
+		
+		private double time;
+		private double flux;
+		private double flux_error;
+		
+		public ObservationReadErrorFITS(String message, double time, double flux, double flux_error) {
+			super(message);
+			this.time = time;
+			this.flux = flux;
+			this.flux_error = flux_error;
+		}
+
+		public double getTime() {
+			return time;
+		}
+		
+		public double getFlux() {
+			return flux;
+		}
+		
+		public double getFluxError() {
+			return flux_error;
+		}
+	}
+	
+	private class RawObservationData {
+		int row;
+		double time;
+		double intensity;
+		double error;
+		Integer quality;
+	}
+	
+	private BasicHDU[] hdus = null;
+	
+	private String objName = null;
+	
+	private ObservationSourcePluginBase hostPlugin;
+	
+	public TESSObservationRetrieverBase(ObservationSourcePluginBase hostPlugin) {
+		super(hostPlugin.getVelaFilterStr());
+		this.hostPlugin = hostPlugin;
+	}
+	
+	/**
+	 * 
+	 * @param hdus
+	 * @return false if the FITS structure does not match the source
+	 */
+	public abstract boolean validateFITS(BasicHDU[] hdus);
+
+	/**
+	 * 
+	 * @param hdus
+	 * @return the series type
+	 */
+	public abstract SeriesType getSeriesType(BasicHDU[] hdus);
+
+	/**
+	 * 
+	 * @param hdus
+	 * @return reference magnitude from the fits header
+	 */
+	public abstract double getRefMagnitude(BasicHDU[] hdus);
+
+	/**
+	 * 
+	 * @param hdus
+	 * @return magnitude description
+	 */
+	public abstract String getRefMagnitudeDescription(BasicHDU[] hdus);
+	
+	/**
+	 * 
+	 * @param hdus
+	 * @return reference epoch
+	 */
+	public abstract Double getTimeRef(BasicHDU[] hdus);
+
+	/**
+	 * 
+	 * @param hdus
+	 * @return column index for the specified column type
+	 */
+	public abstract int getColumnIndex(BasicHDU[] hdus, BinaryTableFieldType field);
+	
+	@Override
+	public void retrieveObservations() throws ObservationReadError,
+			InterruptedException {
+				
+		setJDflavour(JDflavour.BJD);
+		try {
+			// BasicHDU initialization moved to getNumberOfRecords
+			retrieveObservations(hdus);
+		} catch (Exception e) {
+			throw new ObservationReadError(e.getLocalizedMessage());
+		}
+	}
+	
+	private void retrieveObservations(BasicHDU[] hdus)
+			throws FitsException, ObservationReadError {
+
+		if (!validateFITS(hdus)) {
+			throw new ObservationReadError("Not a valid FITS file");
+		}
+		
+		// KEPLER, TESS, QLP and LightKurve FITS
+		if (hdus.length > 1 && hdus[0] instanceof ImageHDU && hdus[1] instanceof BinaryTableHDU) {
+			
+			// Lists to store observations before median level adjust
+			List<RawObservationData> rawObsList = new ArrayList<RawObservationData>();
+			List<InvalidObservation> invalidObsList = new ArrayList<InvalidObservation>();
+
+			ImageHDU imageHDU = (ImageHDU)hdus[0];
+			
+			objName = imageHDU.getObject();
+			SeriesType seriesType = getSeriesType(hdus);
+			double refMag = getRefMagnitude(hdus);
+			String refMagDescription = getRefMagnitudeDescription(hdus);
+			
+			BinaryTableHDU tableHDU = (BinaryTableHDU) hdus[1];
+			
+			int timeColumn        = getColumnIndex(hdus, BinaryTableFieldType.TIME);
+			int fluxColumn        = getColumnIndex(hdus, BinaryTableFieldType.FLUX); 
+			int fluxErrColumn     = getColumnIndex(hdus, BinaryTableFieldType.FLUX_ERROR); 
+			int qalityFlagsColumn = getColumnIndex(hdus, BinaryTableFieldType.QUALITY_FLAGS);
+			
+			Double timeRef = getTimeRef(hdus);
+			if (timeRef == null) {
+				throw new ObservationReadError("Cannot find determine reference epoch");
+			}
+
+			for (int row = 0; row < tableHDU.getNRows()	&& !wasInterrupted(); row++) {
+				try {
+					double barytime = ((double[]) tableHDU.getElement(row, timeColumn))[0];
+					double bjd = barytime + timeRef;
+					
+					float flux = ((float[]) tableHDU.getElement(row, fluxColumn))[0];
+					float flux_err = 0;
+					if (fluxErrColumn >= 0) {
+						flux_err = ((float[]) tableHDU.getElement(row, fluxErrColumn))[0];
+					}
+					Integer qualityFlags = null;
+					if (qalityFlagsColumn >= 0) {
+						qualityFlags = ((int[]) tableHDU.getElement(row, qalityFlagsColumn))[0];
+					}
+
+					if (!Float.isInfinite(flux)	&& 
+						!Float.isInfinite(flux_err)	&& 
+						!Float.isNaN(flux) && 
+						!Float.isNaN(flux_err) && 
+						(flux > 0))
+					{
+						RawObservationData rawObs = new RawObservationData();
+						rawObs.row = row;
+						rawObs.time = bjd;
+						rawObs.intensity = flux;
+						rawObs.error = flux_err;
+						rawObs.quality = qualityFlags;
+						
+						rawObsList.add(rawObs);							
+					} else {
+						throw new ObservationReadErrorFITS("Invalid flux or flux error", bjd, flux, flux_err);
+					}
+				} catch (Exception e) {
+					String input;
+					if (e instanceof ObservationReadErrorFITS) {
+						input = String.format(Locale.ENGLISH, "Time = %f, Flux = %f, Flux error = %f", 
+								((ObservationReadErrorFITS)e).getTime(), 
+								((ObservationReadErrorFITS)e).getFlux(), 
+								((ObservationReadErrorFITS)e).getFluxError());
+					} else {
+						input = "";
+					}
+					String error = e.getLocalizedMessage();
+					InvalidObservation ob = new InvalidObservation(input, error);
+					ob.setRecordNumber(row);
+					invalidObsList.add(ob);
+				}
+			}
+			
+			// Calculating magShift (median of all points)
+			double magShift = 15.0; // arbitrary value
+			if (refMag != INVALID_MAG) {
+				double flux[] = new double[rawObsList.size()];
+				for (int i = 0; i < rawObsList.size(); i++) {
+					flux[i] = rawObsList.get(i).intensity;
+				}
+				Median median = new Median();
+				double median_flux = median.evaluate(flux);
+				double median_inst_mag = -2.5 * Math.log10(median_flux);
+				magShift = refMag - median_inst_mag;
+			}
+			
+			for (RawObservationData rawObs : rawObsList) {
+				double mag = magShift - 2.5 * Math.log10(rawObs.intensity);
+				double magErr = 1.086 * rawObs.error / rawObs.intensity;
+				
+				ValidObservation ob = new ValidObservation();
+				if (objName != null && !"".equals(objName.trim())) {
+					ob.setName(objName);
+				} else {
+					ob.setName(hostPlugin.getInputName());
+				}
+				ob.setDateInfo(new DateInfo(rawObs.time));
+				ob.setMagnitude(new Magnitude(mag, magErr));
+				ob.setBand(seriesType);
+				ob.setRecordNumber(rawObs.row);
+				if (refMagDescription != null) {
+					ob.addDetail(
+							"HEADER_MAG",
+							refMag != INVALID_MAG ? NumericPrecisionPrefs.getOtherOutputFormat().format(refMag) : "",
+							refMagDescription);
+				};
+				ob.addDetail("FLUX",NumericPrecisionPrefs.getOtherOutputFormat().format(rawObs.intensity), "Flux");
+				if (qalityFlagsColumn >= 0) {
+					ob.addDetail("QUALITY",	rawObs.quality != null ? rawObs.quality.toString() : "", "Quality");
+				}
+				collectObservation(ob);
+				incrementProgress();
+			}
+
+			for (InvalidObservation ob : invalidObsList) {
+				addInvalidObservation(ob);
+				incrementProgress();
+			}
+		} else {
+			throw new ObservationReadError("Not a valid FITS file");
+		}
+		
+	}
+	
+	@Override
+	public Integer getNumberOfRecords() throws ObservationReadError {
+		if (hdus == null) {
+			try {
+				Fits fits = new Fits(hostPlugin.getInputStreams().get(0));
+				hdus = fits.read();
+			} catch (Exception e) {
+				throw new ObservationReadError(e.getLocalizedMessage());
+			}
+		}
+		if (hdus.length > 1 && hdus[1] instanceof BinaryTableHDU) {
+			BinaryTableHDU tableHDU = (BinaryTableHDU) hdus[1];
+			return tableHDU.getNRows();
+		} else {
+			throw new ObservationReadError("Not a valid FITS file");
+		}
+	}
+
+	@Override
+	public String getSourceName() {
+		return hostPlugin.getInputName();
+	}
+	
+	@Override
+	public StarInfo getStarInfo() {
+		String name = objName;
+		if (name == null || "".equals(name.trim())) {
+			name = getSourceName();
+		}
+		return new StarInfo(this, name);
+	}
+
+}

--- a/src/org/aavso/tools/vstar/ui/resources/RevisionAccessor.java
+++ b/src/org/aavso/tools/vstar/ui/resources/RevisionAccessor.java
@@ -26,8 +26,8 @@ import java.util.regex.Pattern;
 
 public class RevisionAccessor {
 
-	private static String REVISION = "77457812";
-	private static String BUILD_TIME = "2023-03-25 20:15";
+	private static String REVISION = "b672d701";
+	private static String BUILD_TIME = "2023-03-31 13:07";
 
 	/**
 	 * Get the latest git revision


### PR DESCRIPTION

Issue #342: KEPLER/TESS, QLP, LightKurve plug-ins now derive their ObservationRetriever's from TESSObservationRetrieverBase. 
A new observation detail -- "Flux" -- was added.
FITS rows having bad flux/flux_error are now collected to the invalid observations list.