### PR TITLE
#386: changed _64 to 64 in grep

### DIFF
--- a/VStar.sh
+++ b/VStar.sh
@@ -5,7 +5,7 @@
 APP_DIR=$(dirname "$0")
 
 # 32 or 64 bit?
-VER=`uname -a | grep _64`
+VER=`uname -a | grep 64`
 
 if [ "$VER" != "" ]; then
     # 64 bit, so determine half of available memory for Mac OS X or Linux


### PR DESCRIPTION
It's a small change. Tested on Mac M2. Will check on Raspberry Pi. If you have a Linux machine, feel free to check there if you like @mpyat2.