### PR TITLE
424: changed exception handling in text format obs reader

### DIFF
--- a/src/org/aavso/tools/vstar/plugin/ObservationSourcePluginBase.java
+++ b/src/org/aavso/tools/vstar/plugin/ObservationSourcePluginBase.java
@@ -19,6 +19,7 @@ package org.aavso.tools.vstar.plugin;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
@@ -93,7 +94,7 @@ public abstract class ObservationSourcePluginBase implements IPlugin {
 	 * 
 	 * @return An observation retriever.
 	 */
-	public abstract AbstractObservationRetriever getObservationRetriever();
+	public abstract AbstractObservationRetriever getObservationRetriever() throws IOException, ObservationReadError;
 
 	/**
 	 * Get the name of the star associated with the current observation dataset.
@@ -351,9 +352,10 @@ public abstract class ObservationSourcePluginBase implements IPlugin {
 	 * @return The observation retriever
 	 * @throws InterruptedException
 	 * @throws ObservationReadError
+	 * @throws IOException
 	 */
 	protected AbstractObservationRetriever getTestRetriever(String[] lines, String inputName)
-			throws InterruptedException, ObservationReadError {
+			throws InterruptedException, ObservationReadError, IOException {
 		StringBuffer content = new StringBuffer();
 		for (String line : lines) {
 			content.append(line);

--- a/src/org/aavso/tools/vstar/plugin/ob/src/impl/TextFormatObservationSourcePlugin.java
+++ b/src/org/aavso/tools/vstar/plugin/ob/src/impl/TextFormatObservationSourcePlugin.java
@@ -19,12 +19,14 @@ package org.aavso.tools.vstar.plugin.ob.src.impl;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.aavso.tools.vstar.exception.ObservationReadError;
 import org.aavso.tools.vstar.input.AbstractObservationRetriever;
 import org.aavso.tools.vstar.input.text.ObservationSourceAnalyser;
 import org.aavso.tools.vstar.input.text.TextFormatObservationReader;
@@ -76,53 +78,47 @@ public class TextFormatObservationSourcePlugin extends
 	}
 
 	@Override
-	public AbstractObservationRetriever getObservationRetriever() {
+	public AbstractObservationRetriever getObservationRetriever() throws IOException, ObservationReadError {
 
 		AbstractObservationRetriever retriever = null;
 
 		byte[] allBytes = null;
 		List<byte[]> byteArrayList = new ArrayList<byte[]>();
 		int total = 0;
-		try {
-			InputStream stream = getInputStreams().get(0);
 
-			BufferedReader streamReader = new BufferedReader(
-					new InputStreamReader(stream));
+		InputStream stream = getInputStreams().get(0);
 
-			// Obtain bytes from stream in order to re-use in analyser and
-			// reader.
-			String line;
-			while ((line = streamReader.readLine()) != null) {
+		BufferedReader streamReader = new BufferedReader(
+				new InputStreamReader(stream));
 
-				byte[] bytes = line.getBytes();
-				byteArrayList.add(bytes);
-				total += bytes.length + 1;
-			}
+		// Obtain bytes from stream in order to re-use in analyser and
+		// reader.
+		String line;
+		while ((line = streamReader.readLine()) != null) {
 
-			int i = 0;
-			allBytes = new byte[total];
-			for (byte[] bytes : byteArrayList) {
-				for (byte b : bytes) {
-					allBytes[i++] = b;
-				}
-				allBytes[i++] = '\n';
-			}
-
-			// Analyse the observation file and create an observation retriever.
-			analyser = new ObservationSourceAnalyser(new LineNumberReader(
-					new InputStreamReader(new ByteArrayInputStream(allBytes))),
-					getInputName());
-			analyser.analyse();
-
-			retriever = new TextFormatObservationReader(new LineNumberReader(
-					new InputStreamReader(new ByteArrayInputStream(allBytes))),
-					analyser, getVelaFilterStr());
-
-		} catch (Exception e) {
-			// TODO: move analyser creation into reader class so we can handle
-			// this more efficiently, passing top-level stream not reader...or perhaps
-			// pass lines, handling exception there
+			byte[] bytes = line.getBytes();
+			byteArrayList.add(bytes);
+			total += bytes.length + 1;
 		}
+
+		int i = 0;
+		allBytes = new byte[total];
+		for (byte[] bytes : byteArrayList) {
+			for (byte b : bytes) {
+				allBytes[i++] = b;
+			}
+			allBytes[i++] = '\n';
+		}
+
+		// Analyse the observation file and create an observation retriever.
+		analyser = new ObservationSourceAnalyser(new LineNumberReader(
+				new InputStreamReader(new ByteArrayInputStream(allBytes))),
+				getInputName());
+		analyser.analyse();
+
+		retriever = new TextFormatObservationReader(new LineNumberReader(
+				new InputStreamReader(new ByteArrayInputStream(allBytes))),
+				analyser, getVelaFilterStr());
 
 		return retriever;
 	}


### PR DESCRIPTION
Hi @mpyat2

I'm taking the minimal approach here of propagating the exception (removed the `try`..`catch`, added `throw` clause), allowing it to be caught higher up so that it appears in an error dialog box. There are many things that could be done to improve this code, but that's another issue entirely.

A question is whether or not `ObservationReadError` and `IOException` should be unified, e.g. caught and rethrown as `ObservationReadError`? Happy to make that change although one argument against that is that different exceptions thrown give more information, so leaving as multiple exceptions also makes sense.

Let mew know what you think.