### PR TITLE
#495: changed numeric tolerance in compareDftResult() called by dftFerrazMelloTest() from 1e-8 to 1e-7

### DIFF
--- a/plugin/src/org/aavso/tools/vstar/external/plugin/DFTandSpectralWindowTest.java
+++ b/plugin/src/org/aavso/tools/vstar/external/plugin/DFTandSpectralWindowTest.java
@@ -2165,7 +2165,7 @@ public class DFTandSpectralWindowTest {
 			
 			if (expectedDftTopHits.length > topHits.get(PeriodAnalysisCoordinateType.FREQUENCY).size())
 				throw new Exception("Invalid DFT TopHits array length");
-			compareDftResult(expectedDftTopHits, topHits, "TopHits ", 1e-8);
+			compareDftResult(expectedDftTopHits, topHits, "TopHits ", 1e-7);
 
 		}
 		


### PR DESCRIPTION
Let me know what you think @mpyat2. CI/CD is happy too.