### PR TITLE
#532: added shortened/alt names for types

### DIFF
--- a/src/org/aavso/tools/vstar/plugin/filter/impl/VeLaObservationFilterDialog.java
+++ b/src/org/aavso/tools/vstar/plugin/filter/impl/VeLaObservationFilterDialog.java
@@ -149,7 +149,8 @@ public class VeLaObservationFilterDialog extends AbstractOkCancelDialog {
 			@Override
 			public void actionPerformed(ActionEvent e) {
 				String propText = (String) obsPropsList.getSelectedItem();
-				velaFilterField.append(propText);
+				int pos = velaFilterField.getCaretPosition();
+				velaFilterField.insert(propText, pos);
 			}
 		});
 

--- a/src/org/aavso/tools/vstar/ui/vela/VeLaDialog.java
+++ b/src/org/aavso/tools/vstar/ui/vela/VeLaDialog.java
@@ -18,6 +18,8 @@
 package org.aavso.tools.vstar.ui.vela;
 
 import java.awt.Font;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
 import java.io.ByteArrayOutputStream;
 import java.io.FileDescriptor;
 import java.io.FileOutputStream;
@@ -30,6 +32,7 @@ import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JPanel;
+import javax.swing.JTextArea;
 
 import org.aavso.tools.vstar.ui.dialog.ITextComponent;
 import org.aavso.tools.vstar.ui.dialog.MessageBox;
@@ -58,6 +61,8 @@ public class VeLaDialog extends TextDialog {
 
     static {
         codeTextArea = new TextArea("VeLa Code", "", 12, 42, false, true);
+        addKeyListener();
+
         // resultTextArea = new TextAreaTabs(Arrays.asList("Output", "Error",
         // "AST", "DOT"), Arrays.asList("", "", "", ""), 15, 70,
         // true, true);
@@ -164,6 +169,48 @@ public class VeLaDialog extends TextDialog {
     }
 
     // Helpers
+
+    private static void addKeyListener() {
+        JTextArea area = (JTextArea) (codeTextArea.getUIComponent());
+        area.addKeyListener(new KeyAdapter() {
+            boolean escapeMode = false;
+
+            @Override
+            public void keyTyped(KeyEvent e) {
+                char ch = e.getKeyChar();
+                if (ch == '\\') {
+                    escapeMode = true;
+                    e.consume();
+                } else if (escapeMode) {
+
+                    String unicode = null;
+                    switch (ch) {
+                    case 'l':
+                        // lambda
+                        unicode = "\u03BB";
+                        break;
+                    case 'p':
+                        // pi
+                        unicode = "\u03C0";
+                        break;
+                    case 'r':
+                        // real number set
+                        unicode = "\u211D";
+                        break;
+                    case 'z':
+                        // integer number set
+                        unicode = "\u2124";
+                        break;
+                    }
+
+                    e.consume();
+                    int pos = area.getCaretPosition();
+                    area.insert(unicode, pos);
+                    escapeMode = false;
+                }
+            }
+        });
+    }
 
     private void execute() {
         boolean verbose = verbosityCheckBox.isSelected();

--- a/src/org/aavso/tools/vstar/ui/vela/VeLaDialog.java
+++ b/src/org/aavso/tools/vstar/ui/vela/VeLaDialog.java
@@ -180,11 +180,7 @@ public class VeLaDialog extends TextDialog {
                 char ch = e.getKeyChar();
                 String newCh = null;
 
-                if (ch == '\\') {
-                    escapeMode = true;
-                    e.consume();
-                } else if (escapeMode) {
-
+                if (escapeMode) {
                     switch (ch) {
                     case 'l':
                         // lambda
@@ -208,12 +204,15 @@ public class VeLaDialog extends TextDialog {
                         break;
                     }
 
-                    if (newCh != "\\")
-                        e.consume();
+                    e.consume();
 
                     int pos = area.getCaretPosition();
                     area.insert(newCh, pos);
                     escapeMode = false;
+
+                } else if (ch == '\\') {
+                    escapeMode = true;
+                    e.consume();
                 }
             }
         });

--- a/src/org/aavso/tools/vstar/ui/vela/VeLaDialog.java
+++ b/src/org/aavso/tools/vstar/ui/vela/VeLaDialog.java
@@ -178,34 +178,41 @@ public class VeLaDialog extends TextDialog {
             @Override
             public void keyTyped(KeyEvent e) {
                 char ch = e.getKeyChar();
+                String newCh = null;
+
                 if (ch == '\\') {
                     escapeMode = true;
                     e.consume();
                 } else if (escapeMode) {
 
-                    String unicode = null;
                     switch (ch) {
                     case 'l':
                         // lambda
-                        unicode = "\u03BB";
+                        newCh = "\u03BB";
                         break;
                     case 'p':
                         // pi
-                        unicode = "\u03C0";
+                        newCh = "\u03C0";
                         break;
                     case 'r':
                         // real number set
-                        unicode = "\u211D";
+                        newCh = "\u211D";
                         break;
                     case 'z':
                         // integer number set
-                        unicode = "\u2124";
+                        newCh = "\u2124";
+                        break;
+                    case '\\':
+                        // backslash
+                        newCh = "\\";
                         break;
                     }
 
-                    e.consume();
+                    if (newCh != "\\")
+                        e.consume();
+
                     int pos = area.getCaretPosition();
-                    area.insert(unicode, pos);
+                    area.insert(newCh, pos);
                     escapeMode = false;
                 }
             }

--- a/src/org/aavso/tools/vstar/vela/Type.java
+++ b/src/org/aavso/tools/vstar/vela/Type.java
@@ -28,147 +28,164 @@ import org.aavso.tools.vstar.data.Property;
  */
 public enum Type {
 
-	INTEGER, REAL, BOOLEAN, STRING, LIST, FUNCTION, OBJECT, NONE;
+    INTEGER, REAL, BOOLEAN, STRING, LIST, FUNCTION, OBJECT, NONE;
 
-	public final static int[] INT_ARR = new int[0];
-	public final static double[] DBL_ARR = new double[0];
-	public final static Double[] DBL_CLASS_ARR = new Double[0];
-	public final static boolean[] BOOL_ARR = new boolean[0];
-	public final static String[] STR_ARR = new String[0];
+    public final static int[] INT_ARR = new int[0];
+    public final static double[] DBL_ARR = new double[0];
+    public final static Double[] DBL_CLASS_ARR = new Double[0];
+    public final static boolean[] BOOL_ARR = new boolean[0];
+    public final static String[] STR_ARR = new String[0];
 
-	public static Type java2Vela(Class<?> jtype) {
-		Type vtype = null;
-		
-		if (jtype == int.class) {
-			vtype = INTEGER;
-		} else if (jtype == double.class) {
-			vtype = REAL;
-		} else if (jtype == String.class) {
-			vtype = STRING;
-		} else if (jtype == CharSequence.class) {
-			vtype = STRING;
-		} else if (jtype == boolean.class) {
-			vtype = BOOLEAN;
-		} else if (jtype == List.class) {
-			vtype = LIST;
-		} else if (jtype == INT_ARR.getClass()) {
-			vtype = LIST;
-		} else if (jtype == DBL_ARR.getClass()) {
-			vtype = LIST;
-		} else if (jtype == DBL_CLASS_ARR.getClass()) {
-			vtype = LIST;
-		} else if (jtype == BOOL_ARR.getClass()) {
-			vtype = LIST;
-		} else if (jtype == STR_ARR.getClass()) {
-			vtype = LIST;
-		} else if (jtype == void.class) {
-			vtype = NONE;
-		} else {
-			// It's a class representing instances of *some* kind of object!
-			vtype = OBJECT;
+    public static Type java2Vela(Class<?> jtype) {
+        Type vtype = null;
+
+        if (jtype == int.class) {
+            vtype = INTEGER;
+        } else if (jtype == double.class) {
+            vtype = REAL;
+        } else if (jtype == String.class) {
+            vtype = STRING;
+        } else if (jtype == CharSequence.class) {
+            vtype = STRING;
+        } else if (jtype == boolean.class) {
+            vtype = BOOLEAN;
+        } else if (jtype == List.class) {
+            vtype = LIST;
+        } else if (jtype == INT_ARR.getClass()) {
+            vtype = LIST;
+        } else if (jtype == DBL_ARR.getClass()) {
+            vtype = LIST;
+        } else if (jtype == DBL_CLASS_ARR.getClass()) {
+            vtype = LIST;
+        } else if (jtype == BOOL_ARR.getClass()) {
+            vtype = LIST;
+        } else if (jtype == STR_ARR.getClass()) {
+            vtype = LIST;
+        } else if (jtype == void.class) {
+            vtype = NONE;
+        } else {
+            // It's a class representing instances of *some* kind of object!
+            vtype = OBJECT;
 //		} else {
 //			throw new IllegalArgumentException("Invalid type: " + jtype);
-		}
+        }
 
-		return vtype;
-	}
+        return vtype;
+    }
 
-	public static Class<?> vela2Java(Type vtype) {
-		Class<?> jtype = null;
+    public static Class<?> vela2Java(Type vtype) {
+        Class<?> jtype = null;
 
-		switch (vtype) {
-		case INTEGER:
-			jtype = int.class;
-			break;
-		case REAL:
-			jtype = double.class;
-			break;
-		case STRING:
-			jtype = String.class;
-			break;
-		case BOOLEAN:
-			jtype = boolean.class;
-			break;
-		case LIST:
-			// TODO
-			break;
-		case FUNCTION:
-			// TODO
-			break;
-		case NONE:
-			jtype = void.class;
-			break;
-		case OBJECT:
-			jtype = Object.class;
-			break;
-		}
+        switch (vtype) {
+        case INTEGER:
+            jtype = int.class;
+            break;
+        case REAL:
+            jtype = double.class;
+            break;
+        case STRING:
+            jtype = String.class;
+            break;
+        case BOOLEAN:
+            jtype = boolean.class;
+            break;
+        case LIST:
+            // TODO
+            break;
+        case FUNCTION:
+            // TODO
+            break;
+        case NONE:
+            jtype = void.class;
+            break;
+        case OBJECT:
+            jtype = Object.class;
+            break;
+        }
 
-		return jtype;
-	}
+        return jtype;
+    }
 
-	public static Type name2Vela(String type) {
-		Type vtype = null;
+    public static Type name2Vela(String type) {
+        Type vtype = null;
 
-		if ("integer".equalsIgnoreCase(type)) {
-			vtype = INTEGER;
-		} else if ("real".equalsIgnoreCase(type)) {
-			vtype = REAL;
-		} else if ("string".equalsIgnoreCase(type)) {
-			vtype = STRING;
-		} else if ("boolean".equalsIgnoreCase(type)) {
-			vtype = BOOLEAN;
-		} else if ("list".equalsIgnoreCase(type)) {
-			vtype = LIST;
-		} else if ("function".equalsIgnoreCase(type)) {
-			vtype = FUNCTION;
-		} else if ("λ".equalsIgnoreCase(type)) {
+        switch(type.toLowerCase()) {
+        case "int":
+        case "integer":
+        case "ℤ":
+            vtype = INTEGER;
+            break;
+
+        case "real":
+        case "ℝ":
+            vtype = REAL;
+            break;
+
+        case "bool":
+        case "boolean":
+        case "𝔹":
+            vtype = BOOLEAN;
+            break;
+
+        case "str":
+        case "string":
+            vtype = STRING;
+            break;
+
+        case "list":
+            vtype = LIST;
+            break;
+
+        case "fun":
+        case "function":
+        case "λ":
+        case "Λ":
             vtype = FUNCTION;
-        } else {
-			throw new IllegalArgumentException("Invalid type: " + type);
-		}
+            break;
+        }
 
-		return vtype;
-	}
+        return vtype;
+    }
 
-	public static Type propertyToVela(Property prop) {
-		Type vtype = null;
+    public static Type propertyToVela(Property prop) {
+        Type vtype = null;
 
-		switch(prop.getType()) {
-		case INTEGER:
-			vtype = Type.INTEGER;
-			break;
-		case REAL:
-			vtype = Type.REAL;
-			break;
-		case BOOLEAN:
-			vtype = Type.BOOLEAN;
-			break;
-		case STRING:
-			vtype = Type.STRING;
-			break;
-		case NONE:
-		default:
-			vtype = Type.NONE;
-			break;
-		}
+        switch (prop.getType()) {
+        case INTEGER:
+            vtype = Type.INTEGER;
+            break;
+        case REAL:
+            vtype = Type.REAL;
+            break;
+        case BOOLEAN:
+            vtype = Type.BOOLEAN;
+            break;
+        case STRING:
+            vtype = Type.STRING;
+            break;
+        case NONE:
+        default:
+            vtype = Type.NONE;
+            break;
+        }
 
-		return vtype;
-	}
+        return vtype;
+    }
 
-	public boolean isComposite() {
-		return this == LIST || this == FUNCTION || this == OBJECT;
-	}
+    public boolean isComposite() {
+        return this == LIST || this == FUNCTION || this == OBJECT;
+    }
 
-	public boolean oneOf(Type... types) {
-		boolean result = false;
+    public boolean oneOf(Type... types) {
+        boolean result = false;
 
-		for (Type type : types) {
-			if (this == type) {
-				result = true;
-				break;
-			}
-		}
+        for (Type type : types) {
+            if (this == type) {
+                result = true;
+                break;
+            }
+        }
 
-		return result;
-	}
+        return result;
+    }
 }

--- a/src/org/aavso/tools/vstar/vela/VeLa.g4
+++ b/src/org/aavso/tools/vstar/vela/VeLa.g4
@@ -371,7 +371,6 @@ BOOL_T
 :
     [Bb] [Oo] [Oo] [Ll] [Ee] [Aa] [Nn]
     | [Bb] [Oo] [Oo] [Ll]
-    | '𝔹'
 ;
 
 STR_T

--- a/src/org/aavso/tools/vstar/vela/VeLa.g4
+++ b/src/org/aavso/tools/vstar/vela/VeLa.g4
@@ -346,30 +346,38 @@ WHILE
 FUN
 :
     [Ff] [Uu] [Nn] [Cc] [Tt] [Ii] [Oo] [Nn]
+    | [Ff] [Uu] [Nn]
 ;
 
+// lower (λ) and upper (Λ) case lambdas, respectively
 LAMBDA
-:   '\u039B' | '\u03BB'
+:   '\u03BB' | '\u039B'
 ;
 
 INT_T
 :
     [Ii] [Nn] [Tt] [Ee] [Gg] [Ee] [Rr]
+    | [Ii] [Nn] [Tt]
+    | 'ℤ'
 ;
 
 REAL_T
 :
     [Rr] [Ee] [Aa] [Ll]
+    | 'ℝ'
 ;
 
 BOOL_T
 :
     [Bb] [Oo] [Oo] [Ll] [Ee] [Aa] [Nn]
+    | [Bb] [Oo] [Oo] [Ll]
+    | '𝔹'
 ;
 
 STR_T
 :
     [Ss] [Tt] [Rr] [Ii] [Nn] [Gg]
+    | [Ss] [Tt] [Rr]
 ;
 
 LIST_T

--- a/test/org/aavso/tools/vstar/vela/VeLaTest.java
+++ b/test/org/aavso/tools/vstar/vela/VeLaTest.java
@@ -1767,6 +1767,66 @@ public class VeLaTest extends TestCase implements WithQuickTheories {
         assertTrue(Tolerance.areClose(3.8834545, result.get().doubleVal(), 1e-7, true));
     }
 
+    public void testIntegerTypeNameZ() {
+        String prog = "";
+        prog += "f(n : ℤ) : ℤ {n*n}";
+        prog += "f(4)";
+
+        Optional<Operand> result = vela.program(prog);
+        assertTrue(result.isPresent());
+        assertEquals(16, result.get().intVal());
+    }
+
+    public void testIntegerTypeNameInt() {
+        String prog = "";
+        prog += "f(n : int) : int {n*n}";
+        prog += "f(4)";
+
+        Optional<Operand> result = vela.program(prog);
+        assertTrue(result.isPresent());
+        assertEquals(16, result.get().intVal());
+    }
+
+    public void testtRealTypeNameℝ() {
+        String prog = "";
+        prog += "f(n : ℝ) : ℝ {n*n}";
+        prog += "f(4.0)";
+
+        Optional<Operand> result = vela.program(prog);
+        assertTrue(result.isPresent());
+        assertEquals(16.0, result.get().doubleVal());
+    }
+
+    public void testBooleanTypeName𝔹() {
+        String prog = "";
+        prog += "f(b : 𝔹) : 𝔹 {not b}";
+        prog += "f(false)";
+
+        Optional<Operand> result = vela.program(prog);
+        assertTrue(result.isPresent());
+        assertTrue(result.get().booleanVal());
+    }
+
+    public void testBooleanTypeNameBool() {
+        String prog = "";
+        prog += "f(b : bool) : bool {not b}";
+        prog += "f(false)";
+
+        Optional<Operand> result = vela.program(prog);
+        assertTrue(result.isPresent());
+        assertTrue(result.get().booleanVal());
+    }
+
+    public void testtStringTypeNameStr() {
+        String prog = "";
+        prog += "f(s : str) : str {s+s}";
+        prog += "f(\"z\")";
+
+        Optional<Operand> result = vela.program(prog);
+        assertTrue(result.isPresent());
+        assertEquals("zz", result.get().stringVal());
+    }
+
     // Bindings
 
     public void testBindingNonConstant() {
@@ -1909,18 +1969,19 @@ public class VeLaTest extends TestCase implements WithQuickTheories {
         assertTrue(result.isPresent());
         assertEquals(13, result.get().intVal());
     }
+
     // Sequence
 
     public void testSequence() {
         String prog = "";
-        prog += "str <- \"\"";
+        prog += "s <- \"\"";
         prog += "ch is \"1\"";
-        prog += "str <- when";
-        prog += "           ch = \"1\" -> str + \" ONE\"";
-        prog += "           ch = \"2\" -> str + \" TWO\"";
-        prog += "           true -> { println(\"OTHER\") str }\n";
-        // prog += "println(format(\"%s: '%s'\" [ch str]))";
-        prog += "str";
+        prog += "s <- when";
+        prog += "           ch = \"1\" -> s + \" ONE\"";
+        prog += "           ch = \"2\" -> s + \" TWO\"";
+        prog += "           true -> { println(\"OTHER\") s }\n";
+        // prog += "println(format(\"%s: '%s'\" [ch s]))";
+        prog += "s";
 
         Optional<Operand> result = vela.program(prog);
 

--- a/test/org/aavso/tools/vstar/vela/VeLaTest.java
+++ b/test/org/aavso/tools/vstar/vela/VeLaTest.java
@@ -1797,16 +1797,6 @@ public class VeLaTest extends TestCase implements WithQuickTheories {
         assertEquals(16.0, result.get().doubleVal());
     }
 
-    public void testBooleanTypeName𝔹() {
-        String prog = "";
-        prog += "f(b : 𝔹) : 𝔹 {not b}";
-        prog += "f(false)";
-
-        Optional<Operand> result = vela.program(prog);
-        assertTrue(result.isPresent());
-        assertTrue(result.get().booleanVal());
-    }
-
     public void testBooleanTypeNameBool() {
         String prog = "";
         prog += "f(b : bool) : bool {not b}";


### PR DESCRIPTION
Hi @mpyat2. I've added shortcuts for some types as per #532 including escape-based keyboard shortcuts to the VeLa dialog, e.g. type `\` (which won't display) followed by `l`, `p`, `r` or `z` to see the effect (the `\` is consumed so you won't see it). More such shortcuts may be added over time. I removed `\b` for Boolean for now because of some contention over what Unicode character could/should be used.