### PR TITLE
#532: added double strike B for Boolean

### DIFF
--- a/src/org/aavso/tools/vstar/ui/vela/VeLaDialog.java
+++ b/src/org/aavso/tools/vstar/ui/vela/VeLaDialog.java
@@ -182,6 +182,10 @@ public class VeLaDialog extends TextDialog {
 
                 if (escapeMode) {
                     switch (ch) {
+                    case 'b':
+                        // Boolean set
+                        newCh = "\uD835\uDD39";
+                        break;
                     case 'l':
                         // lambda
                         newCh = "\u03BB";

--- a/src/org/aavso/tools/vstar/vela/VeLa.g4
+++ b/src/org/aavso/tools/vstar/vela/VeLa.g4
@@ -371,6 +371,7 @@ BOOL_T
 :
     [Bb] [Oo] [Oo] [Ll] [Ee] [Aa] [Nn]
     | [Bb] [Oo] [Oo] [Ll]
+    | '𝔹'
 ;
 
 STR_T

--- a/test/org/aavso/tools/vstar/vela/VeLaTest.java
+++ b/test/org/aavso/tools/vstar/vela/VeLaTest.java
@@ -1797,6 +1797,16 @@ public class VeLaTest extends TestCase implements WithQuickTheories {
         assertEquals(16.0, result.get().doubleVal());
     }
 
+    public void testBooleanTypeName𝔹() {
+        String prog = "";
+        prog += "f(b : 𝔹) : 𝔹 {not b}";
+        prog += "f(false)";
+
+        Optional<Operand> result = vela.program(prog);
+        assertTrue(result.isPresent());
+        assertTrue(result.get().booleanVal());
+    }
+
     public void testBooleanTypeNameBool() {
         String prog = "";
         prog += "f(b : bool) : bool {not b}";


### PR DESCRIPTION
Realised I could add `𝔹` after all and that it made sense based on a precedent in at least one language (Agda) @mpyat2. Will just sneak this one through. :)