### PR TITLE
Expand property-based tests as foundation for formal verification

### DIFF
--- a/test/org/aavso/tools/vstar/data/PropertyPBTTest.java
+++ b/test/org/aavso/tools/vstar/data/PropertyPBTTest.java
@@ -1,0 +1,215 @@
+/**
+ * VStar: a statistical analysis tool for variable star data.
+ * Copyright (C) 2009  AAVSO (http://www.aavso.org/)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ */
+package org.aavso.tools.vstar.data;
+
+import junit.framework.TestCase;
+
+import org.quicktheories.WithQuickTheories;
+import org.quicktheories.core.Gen;
+
+/**
+ * Property-based tests for the Property class, verifying algebraic contracts
+ * of equals, hashCode, and compareTo.
+ *
+ * These properties are the Java equivalents of the axioms that a formal
+ * verification (e.g. in KeY or Lean) would prove unconditionally.
+ */
+public class PropertyPBTTest extends TestCase implements WithQuickTheories {
+
+	public PropertyPBTTest(String name) {
+		super(name);
+	}
+
+	// -- Generators for Property instances --
+
+	private Gen<Property> intProperties() {
+		return integers().all().map(Property::new);
+	}
+
+	private Gen<Property> realProperties() {
+		return doubles().between(-1e15, 1e15).map(Property::new);
+	}
+
+	private Gen<Property> boolProperties() {
+		return booleans().all().map(Property::new);
+	}
+
+	private Gen<Property> stringProperties() {
+		return strings().basicLatinAlphabet().ofLengthBetween(0, 20)
+				.map(Property::new);
+	}
+
+	// -- equals: reflexivity --
+
+	public void testEqualsReflexiveIntProperty() {
+		qt().forAll(intProperties()).check(p -> p.equals(p));
+	}
+
+	public void testEqualsReflexiveRealProperty() {
+		qt().forAll(realProperties()).check(p -> p.equals(p));
+	}
+
+	public void testEqualsReflexiveBoolProperty() {
+		qt().forAll(boolProperties()).check(p -> p.equals(p));
+	}
+
+	public void testEqualsReflexiveStringProperty() {
+		qt().forAll(stringProperties()).check(p -> p.equals(p));
+	}
+
+	// -- equals: symmetry (via two identical constructions) --
+
+	public void testEqualsSymmetricIntProperty() {
+		qt().forAll(integers().all()).check(v -> {
+			Property a = new Property(v);
+			Property b = new Property(v);
+			return a.equals(b) == b.equals(a);
+		});
+	}
+
+	public void testEqualsSymmetricRealProperty() {
+		qt().forAll(doubles().between(-1e15, 1e15)).check(v -> {
+			Property a = new Property(v);
+			Property b = new Property(v);
+			return a.equals(b) == b.equals(a);
+		});
+	}
+
+	public void testEqualsSymmetricStringProperty() {
+		qt().forAll(strings().basicLatinAlphabet().ofLengthBetween(0, 20))
+				.check(v -> {
+					Property a = new Property(v);
+					Property b = new Property(v);
+					return a.equals(b) == b.equals(a);
+				});
+	}
+
+	// -- hashCode: consistency with equals --
+
+	public void testHashCodeConsistentWithEqualsIntProperty() {
+		qt().forAll(integers().all()).check(v -> {
+			Property a = new Property(v);
+			Property b = new Property(v);
+			return !a.equals(b) || a.hashCode() == b.hashCode();
+		});
+	}
+
+	public void testHashCodeConsistentWithEqualsRealProperty() {
+		qt().forAll(doubles().between(-1e15, 1e15)).check(v -> {
+			Property a = new Property(v);
+			Property b = new Property(v);
+			return !a.equals(b) || a.hashCode() == b.hashCode();
+		});
+	}
+
+	public void testHashCodeConsistentWithEqualsStringProperty() {
+		qt().forAll(strings().basicLatinAlphabet().ofLengthBetween(0, 20))
+				.check(v -> {
+					Property a = new Property(v);
+					Property b = new Property(v);
+					return !a.equals(b) || a.hashCode() == b.hashCode();
+				});
+	}
+
+	// -- compareTo: antisymmetry (sgn(a.compareTo(b)) == -sgn(b.compareTo(a))) --
+
+	public void testCompareToAntisymmetricIntProperty() {
+		qt().forAll(integers().all(), integers().all()).check((v1, v2) -> {
+			Property a = new Property(v1);
+			Property b = new Property(v2);
+			return Integer.signum(a.compareTo(b)) == -Integer
+					.signum(b.compareTo(a));
+		});
+	}
+
+	public void testCompareToAntisymmetricRealProperty() {
+		qt().forAll(doubles().between(-1e15, 1e15),
+				doubles().between(-1e15, 1e15)).check((v1, v2) -> {
+			Property a = new Property(v1);
+			Property b = new Property(v2);
+			return Integer.signum(a.compareTo(b)) == -Integer
+					.signum(b.compareTo(a));
+		});
+	}
+
+	public void testCompareToAntisymmetricStringProperty() {
+		qt().forAll(strings().basicLatinAlphabet().ofLengthBetween(0, 20),
+				strings().basicLatinAlphabet().ofLengthBetween(0, 20))
+				.check((v1, v2) -> {
+					Property a = new Property(v1);
+					Property b = new Property(v2);
+					return Integer.signum(a.compareTo(b)) == -Integer
+							.signum(b.compareTo(a));
+				});
+	}
+
+	// -- compareTo: consistency with equals --
+
+	public void testCompareToConsistentWithEqualsIntProperty() {
+		qt().forAll(integers().all()).check(v -> {
+			Property a = new Property(v);
+			Property b = new Property(v);
+			return a.equals(b) && a.compareTo(b) == 0;
+		});
+	}
+
+	public void testCompareToConsistentWithEqualsRealProperty() {
+		qt().forAll(doubles().between(-1e15, 1e15)).check(v -> {
+			Property a = new Property(v);
+			Property b = new Property(v);
+			return a.equals(b) && a.compareTo(b) == 0;
+		});
+	}
+
+	public void testCompareToConsistentWithEqualsStringProperty() {
+		qt().forAll(strings().basicLatinAlphabet().ofLengthBetween(0, 20))
+				.check(v -> {
+					Property a = new Property(v);
+					Property b = new Property(v);
+					return a.equals(b) && a.compareTo(b) == 0;
+				});
+	}
+
+	// -- compareTo: transitivity --
+
+	public void testCompareToTransitiveIntProperty() {
+		qt().forAll(integers().all(), integers().all(), integers().all())
+				.check((v1, v2, v3) -> {
+					Property a = new Property(v1);
+					Property b = new Property(v2);
+					Property c = new Property(v3);
+					if (a.compareTo(b) <= 0 && b.compareTo(c) <= 0) {
+						return a.compareTo(c) <= 0;
+					}
+					return true;
+				});
+	}
+
+	// -- equals: null safety --
+
+	public void testEqualsNullReturnsFalseIntProperty() {
+		qt().forAll(intProperties()).check(p -> !p.equals(null));
+	}
+
+	// -- NO_VALUE sentinel --
+
+	public void testNoValueEquality() {
+		assertTrue(Property.NO_VALUE.equals(new Property()));
+		assertEquals(Property.propType.NONE, Property.NO_VALUE.getType());
+	}
+}

--- a/test/org/aavso/tools/vstar/util/date/HJDConverterPBTTest.java
+++ b/test/org/aavso/tools/vstar/util/date/HJDConverterPBTTest.java
@@ -1,0 +1,179 @@
+/**
+ * VStar: a statistical analysis tool for variable star data.
+ * Copyright (C) 2010  AAVSO (http://www.aavso.org/)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ */
+package org.aavso.tools.vstar.util.date;
+
+import junit.framework.TestCase;
+
+import org.aavso.tools.vstar.util.coords.DecInfo;
+import org.aavso.tools.vstar.util.coords.EpochType;
+import org.aavso.tools.vstar.util.coords.RAInfo;
+import org.quicktheories.WithQuickTheories;
+
+/**
+ * Property-based tests for the J2000 HJD converter.
+ *
+ * These tests express universal properties of the HJD correction and
+ * angle-normalization helpers, suitable for later promotion to formal
+ * proofs (e.g. in Lean 4 or via JML/OpenJML).
+ */
+public class HJDConverterPBTTest extends TestCase implements WithQuickTheories {
+
+	private J2000HJDConverter converter;
+
+	public HJDConverterPBTTest(String name) {
+		super(name);
+	}
+
+	protected void setUp() throws Exception {
+		super.setUp();
+		converter = (J2000HJDConverter) AbstractHJDConverter
+				.getInstance(EpochType.J2000);
+	}
+
+	// -- degsInRange properties --
+
+	/**
+	 * degsInRange always returns a value in [0, 360).
+	 */
+	public void testDegsInRangeOutputRangeProperty() {
+		qt().forAll(doubles().between(-1e6, 1e6)).check(degs -> {
+			double result = converter.degsInRange(degs);
+			return result >= 0 && result < 360.0;
+		});
+	}
+
+	/**
+	 * degsInRange is idempotent: applying it twice gives the same result.
+	 */
+	public void testDegsInRangeIdempotentProperty() {
+		qt().forAll(doubles().between(-1e6, 1e6)).check(degs -> {
+			double once = converter.degsInRange(degs);
+			double twice = converter.degsInRange(once);
+			return Math.abs(once - twice) < 1e-10;
+		});
+	}
+
+	/**
+	 * degsInRange respects 360-degree periodicity.
+	 */
+	public void testDegsInRangePeriodicProperty() {
+		qt().forAll(doubles().between(-1e4, 1e4)).check(degs -> {
+			double r1 = converter.degsInRange(degs);
+			double r2 = converter.degsInRange(degs + 360.0);
+			return Math.abs(r1 - r2) < 1e-9;
+		});
+	}
+
+	// -- radsInRange properties --
+
+	/**
+	 * radsInRange always returns a value in [0, 2*pi).
+	 */
+	public void testRadsInRangeOutputRangeProperty() {
+		final double TWOPI = 2 * Math.PI;
+		qt().forAll(doubles().between(-1e4, 1e4)).check(rads -> {
+			double result = converter.radsInRange(rads);
+			return result >= 0 && result < TWOPI + 1e-12;
+		});
+	}
+
+	/**
+	 * radsInRange is idempotent.
+	 */
+	public void testRadsInRangeIdempotentProperty() {
+		qt().forAll(doubles().between(-1e4, 1e4)).check(rads -> {
+			double once = converter.radsInRange(rads);
+			double twice = converter.radsInRange(once);
+			return Math.abs(once - twice) < 1e-10;
+		});
+	}
+
+	/**
+	 * radsInRange respects 2*pi periodicity.
+	 */
+	public void testRadsInRangePeriodicProperty() {
+		final double TWOPI = 2 * Math.PI;
+		qt().forAll(doubles().between(-1e3, 1e3)).check(rads -> {
+			double r1 = converter.radsInRange(rads);
+			double r2 = converter.radsInRange(rads + TWOPI);
+			return Math.abs(r1 - r2) < 1e-9;
+		});
+	}
+
+	// -- HJD correction bound --
+
+	/**
+	 * The HJD correction is bounded by R_max/c where R_max ~ 1.017 AU and
+	 * c = 173.14 AU/day, giving a maximum correction of ~0.00588 days
+	 * (~8.5 minutes). We use 0.006 days as a generous bound.
+	 *
+	 * This property holds for any sky position and any JD in a reasonable
+	 * historical/future range.
+	 */
+	public void testHJDCorrectionBoundProperty() {
+		final double MAX_CORRECTION_DAYS = 0.006;
+
+		qt().forAll(
+				doubles().between(2415000, 2470000),
+				doubles().between(0.0, 360.0),
+				doubles().between(-90.0, 90.0))
+				.check((jd, raDeg, decDeg) -> {
+					RAInfo ra = new RAInfo(EpochType.J2000, raDeg);
+					DecInfo dec = new DecInfo(EpochType.J2000, decDeg);
+					double hjd = converter.convert(jd, ra, dec);
+					double correction = Math.abs(hjd - jd);
+					return correction <= MAX_CORRECTION_DAYS;
+				});
+	}
+
+	// -- julianCenturies is linear --
+
+	/**
+	 * julianCenturies(jd) is a linear function of jd:
+	 * T(jd + delta) - T(jd) = delta / 36525.
+	 */
+	public void testJulianCenturiesLinearProperty() {
+		qt().forAll(
+				doubles().between(2415000, 2470000),
+				doubles().between(0.1, 365.25))
+				.check((jd, delta) -> {
+					double t1 = converter.julianCenturies(jd);
+					double t2 = converter.julianCenturies(jd + delta);
+					double expected = delta / 36525.0;
+					return Math.abs((t2 - t1) - expected) < 1e-12;
+				});
+	}
+
+	// -- Radius vector bound --
+
+	/**
+	 * The Earth-Sun radius vector R is bounded: approximately
+	 * 0.983 AU (perihelion) <= R <= 1.017 AU (aphelion).
+	 * We use slightly wider bounds for robustness with the low-accuracy model.
+	 */
+	public void testRadiusVectorBoundProperty() {
+		qt().forAll(doubles().between(2415000, 2470000)).check(jd -> {
+			double T = converter.julianCenturies(jd);
+			int year = AbstractDateUtil.getInstance().jdToYMD(jd).getYear();
+			SolarCoords coords = converter.solarCoords(T, year);
+			double R = converter.radiusVector(T, coords.getTrueAnomaly(),
+					coords.getEquationOfCenter());
+			return R >= 0.97 && R <= 1.04;
+		});
+	}
+}

--- a/test/org/aavso/tools/vstar/util/stats/DescStatsPBTTest.java
+++ b/test/org/aavso/tools/vstar/util/stats/DescStatsPBTTest.java
@@ -1,0 +1,191 @@
+/**
+ * VStar: a statistical analysis tool for variable star data.
+ * Copyright (C) 2009  AAVSO (http://www.aavso.org/)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ */
+package org.aavso.tools.vstar.util.stats;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import junit.framework.TestCase;
+
+import org.aavso.tools.vstar.data.DateInfo;
+import org.aavso.tools.vstar.data.Magnitude;
+import org.aavso.tools.vstar.data.MagnitudeModifier;
+import org.aavso.tools.vstar.data.ValidObservation;
+import org.aavso.tools.vstar.ui.model.plot.JDTimeElementEntity;
+import org.quicktheories.WithQuickTheories;
+
+/**
+ * Property-based tests for DescStats.
+ *
+ * These tests express universally quantified properties of descriptive
+ * statistics that hold for all valid inputs, forming a specification
+ * suitable for later promotion to formal proofs.
+ */
+public class DescStatsPBTTest extends TestCase implements WithQuickTheories {
+
+	public DescStatsPBTTest(String name) {
+		super(name);
+	}
+
+	/**
+	 * Sample variance is always non-negative for any list of 2+ observations.
+	 */
+	public void testSampleVarianceNonNegativeProperty() {
+		qt().forAll(
+				lists().of(doubles().between(-30.0, 30.0)).ofSizeBetween(2, 50))
+				.check(mags -> {
+					List<ValidObservation> obs = magsToObs(mags);
+					double var = DescStats.calcMagSampleVarianceInRange(obs, 0,
+							obs.size() - 1);
+					return var >= 0;
+				});
+	}
+
+	/**
+	 * Population variance is always non-negative for any list of 1+ observations.
+	 */
+	public void testPopulationVarianceNonNegativeProperty() {
+		qt().forAll(
+				lists().of(doubles().between(-30.0, 30.0)).ofSizeBetween(1, 50))
+				.check(mags -> {
+					List<ValidObservation> obs = magsToObs(mags);
+					double var = DescStats.calcMagPopulationVarianceInRange(obs,
+							0, obs.size() - 1);
+					return var >= 0;
+				});
+	}
+
+	/**
+	 * Sample variance >= population variance (Bessel's correction increases
+	 * the denominator from N to N-1, so sample variance is always at least as
+	 * large).
+	 */
+	public void testSampleVarianceGeqPopulationVarianceProperty() {
+		qt().forAll(
+				lists().of(doubles().between(-30.0, 30.0)).ofSizeBetween(2, 50))
+				.check(mags -> {
+					List<ValidObservation> obs = magsToObs(mags);
+					int last = obs.size() - 1;
+					double sampleVar = DescStats
+							.calcMagSampleVarianceInRange(obs, 0, last);
+					double popVar = DescStats
+							.calcMagPopulationVarianceInRange(obs, 0, last);
+					return sampleVar >= popVar - 1e-12;
+				});
+	}
+
+	/**
+	 * Standard deviation equals square root of variance (sample).
+	 */
+	public void testStdDevEqualsSqrtVarianceProperty() {
+		qt().forAll(
+				lists().of(doubles().between(-30.0, 30.0)).ofSizeBetween(2, 50))
+				.check(mags -> {
+					List<ValidObservation> obs = magsToObs(mags);
+					int last = obs.size() - 1;
+					double var = DescStats.calcMagSampleVarianceInRange(obs, 0,
+							last);
+					double stdDev = DescStats.calcMagSampleStdDevInRange(obs,
+							0, last);
+					return Math.abs(stdDev - Math.sqrt(var)) < 1e-12;
+				});
+	}
+
+	/**
+	 * Variance is translation-invariant: adding a constant to every magnitude
+	 * should not change the variance.
+	 */
+	public void testVarianceTranslationInvariantProperty() {
+		qt().forAll(
+				lists().of(doubles().between(-15.0, 15.0)).ofSizeBetween(2, 50),
+				doubles().between(-100.0, 100.0))
+				.check((mags, shift) -> {
+					List<ValidObservation> obs = magsToObs(mags);
+					List<Double> shifted = new ArrayList<Double>();
+					for (double m : mags) {
+						shifted.add(m + shift);
+					}
+					List<ValidObservation> shiftedObs = magsToObs(shifted);
+					int last = obs.size() - 1;
+					double var1 = DescStats.calcMagSampleVarianceInRange(obs,
+							0, last);
+					double var2 = DescStats.calcMagSampleVarianceInRange(
+							shiftedObs, 0, last);
+					return Math.abs(var1 - var2) < 1e-8;
+				});
+	}
+
+	/**
+	 * Mean is translation-equivariant: adding a constant to every magnitude
+	 * should shift the mean by the same constant.
+	 */
+	public void testMeanTranslationEquivariantProperty() {
+		qt().forAll(
+				lists().of(doubles().between(-15.0, 15.0)).ofSizeBetween(1, 50),
+				doubles().between(-100.0, 100.0))
+				.check((mags, shift) -> {
+					List<ValidObservation> obs = magsToObs(mags);
+					List<Double> shifted = new ArrayList<Double>();
+					for (double m : mags) {
+						shifted.add(m + shift);
+					}
+					List<ValidObservation> shiftedObs = magsToObs(shifted);
+					int last = obs.size() - 1;
+					double mean1 = DescStats.calcMagMeanInRange(obs,
+							JDTimeElementEntity.instance, 0, last)[DescStats.MEAN_MAG_INDEX];
+					double mean2 = DescStats.calcMagMeanInRange(shiftedObs,
+							JDTimeElementEntity.instance, 0, last)[DescStats.MEAN_MAG_INDEX];
+					return Math.abs((mean2 - mean1) - shift) < 1e-8;
+				});
+	}
+
+	/**
+	 * Variance of a constant sequence is zero.
+	 */
+	public void testConstantSequenceVarianceZeroProperty() {
+		qt().forAll(
+				doubles().between(-30.0, 30.0),
+				integers().between(2, 50))
+				.check((val, size) -> {
+					List<Double> mags = new ArrayList<Double>();
+					for (int i = 0; i < size; i++) {
+						mags.add(val);
+					}
+					List<ValidObservation> obs = magsToObs(mags);
+					double var = DescStats.calcMagPopulationVarianceInRange(obs,
+							0, obs.size() - 1);
+					return Math.abs(var) < 1e-12;
+				});
+	}
+
+	// Helpers
+
+	private List<ValidObservation> magsToObs(List<Double> mags) {
+		double jd = 2450000.0;
+		List<ValidObservation> observations = new ArrayList<ValidObservation>();
+		for (double mag : mags) {
+			ValidObservation obs = new ValidObservation();
+			obs.setMagnitude(new Magnitude(mag, MagnitudeModifier.NO_DELTA,
+					false));
+			obs.setDateInfo(new DateInfo(jd));
+			observations.add(obs);
+			jd += 1.0;
+		}
+		return observations;
+	}
+}

--- a/test/org/aavso/tools/vstar/util/stats/PhaseCalcsTest.java
+++ b/test/org/aavso/tools/vstar/util/stats/PhaseCalcsTest.java
@@ -96,10 +96,7 @@ public class PhaseCalcsTest extends TestCase implements WithQuickTheories {
 		assertEquals(-0.875, observations.get(3).getPreviousCyclePhase());
 	}
 	
-    // This says that given valid inputs, the phase should always
-	// be in the range 0..1 inclusive.
     public void testPhaseInRangeProperty() {
-        // choose a reasonable JD/epoch, and period ranges
         double minJD = 2400000;
         double maxJD = 2460000;
         double minPeriod = 0.0001;
@@ -112,6 +109,50 @@ public class PhaseCalcsTest extends TestCase implements WithQuickTheories {
                 .check((jd, epoch, period) -> {
                     double phase = PhaseCalcs.calcStandardPhase(jd, epoch, period);
                     return phase >= 0 && phase <= 1;
+                });
+    }
+
+    /**
+     * Phase is periodic in JD: shifting JD by one period should not change the
+     * phase (within floating-point tolerance). Comparison uses circular
+     * distance since phases 0.0 and ~1.0 are adjacent on the unit circle.
+     */
+    public void testPhasePeriodicityProperty() {
+        double minJD = 2400000;
+        double maxJD = 2460000;
+        double minPeriod = 0.001;
+        double maxPeriod = 1e4;
+
+        qt().forAll(
+                doubles().between(minJD, maxJD),
+                doubles().between(minJD, maxJD),
+                doubles().from(minPeriod).upToAndIncluding(maxPeriod))
+                .check((jd, epoch, period) -> {
+                    double phase1 = PhaseCalcs.calcStandardPhase(jd, epoch, period);
+                    double phase2 = PhaseCalcs.calcStandardPhase(jd + period, epoch, period);
+                    double diff = Math.abs(phase1 - phase2);
+                    double circularDist = Math.min(diff, 1.0 - diff);
+                    return circularDist < 1e-6;
+                });
+    }
+
+    /**
+     * previousCyclePhase = standardPhase - 1, so it must always lie in [-1, 0].
+     */
+    public void testPreviousCyclePhaseRangeProperty() {
+        double minJD = 2400000;
+        double maxJD = 2460000;
+        double minPeriod = 0.0001;
+        double maxPeriod = 1e6;
+
+        qt().forAll(
+                doubles().between(minJD, maxJD),
+                doubles().between(minJD, maxJD),
+                doubles().from(minPeriod).upToAndIncluding(maxPeriod))
+                .check((jd, epoch, period) -> {
+                    double phase = PhaseCalcs.calcStandardPhase(jd, epoch, period);
+                    double prev = phase - 1;
+                    return prev >= -1 && prev <= 0;
                 });
     }
 


### PR DESCRIPTION
Expand PhaseCalcsTest with periodicity (circular distance) and previousCyclePhase range properties. Add new PBT test classes for DescStats (variance non-negativity, translation invariance, Bessel correction, constant-sequence), Property (equals/hashCode/compareTo algebraic contracts), and J2000HJDConverter (degsInRange/radsInRange range/idempotence/periodicity, HJD correction bound, radius vector bound, julianCenturies linearity). 38 new tests, all passing.

Made-with: Cursor