### PR TITLE
CI: add fail-fast=false and retry wrapper to UT workflows

### DIFF
--- a/.github/workflows/plugin-UT.yml
+++ b/.github/workflows/plugin-UT.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         java: [ '17', '21', '23' ]
 
@@ -40,10 +41,14 @@ jobs:
         mkdir -p ~/vstar_plugin_libs
     - name: Build and test with coverage
       id: tests
-      run: |
-        ant -noinput -buildfile build.xml dist
-        cd plugin
-        ant -noinput -buildfile build.xml coverage-report
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 25
+        max_attempts: 2
+        command: |
+          ant -noinput -buildfile build.xml dist
+          cd plugin
+          ant -noinput -buildfile build.xml coverage-report
 
     - name: Extract test and coverage metrics
       if: always()

--- a/.github/workflows/vstar-UT.yml
+++ b/.github/workflows/vstar-UT.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         java: [ '17', '21', '23' ]
 
@@ -39,8 +40,11 @@ jobs:
         mkdir -p ~/vstar_plugin_libs
     - name: Run tests with coverage
       id: tests
-      run:
-        ant -noinput -buildfile build.xml coverage-report
+      uses: nick-fields/retry@v3
+      with:
+        timeout_minutes: 20
+        max_attempts: 2
+        command: ant -noinput -buildfile build.xml coverage-report
 
     - name: Extract test and coverage metrics
       if: always()


### PR DESCRIPTION
- strategy.fail-fast: false in both vstar-UT.yml and plugin-UT.yml so a flake on one Java matrix cell no longer cancels the other versions (e.g. PR #582 lost Java 23 visibility because Java 21 flaked).
- Wrap the test step with nick-fields/retry@v3 (max_attempts: 2, timeout_minutes: 20 for vstar, 25 for plugin) so transient flakes are auto-retried before surfacing as job failures. steps.tests.outcome still reflects the final attempt, so the existing metrics, PR comment, and dashboard publish steps are unaffected.

Made-with: Cursor