### PR TITLE
#589: deploy plugins to github.io for snapshot and stable releases

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -79,17 +79,21 @@ jobs:
       run: |
         mkdir -p _site/grammar
         cp /tmp/rrd-antlr4/target/output/VeLa/index.html _site/grammar/VeLa.html
-    - name: Commit and push VeLa grammar diagram to gh-pages
+    - name: Deploy plugins to gh-pages (snapshot)
+      run: |
+        mkdir -p _site/plugins/snapshot
+        unzip -q plugin/vstar-plugins.zip -d _site/plugins/snapshot/
+    - name: Commit and push to gh-pages
       working-directory: _site
       run: |
         git config user.email "github-actions[bot]@users.noreply.github.com"
         git config user.name "github-actions[bot]"
-        git add grammar/VeLa.html
+        git add -A
         if git diff --cached --quiet; then
-          echo "No VeLa grammar diagram changes to publish."
+          echo "No changes to publish."
           exit 0
         fi
-        git commit -m "Update VeLa grammar railroad diagram"
+        git commit -m "Update VeLa grammar diagram and snapshot plugins"
         for i in 1 2 3; do
           git pull --rebase origin gh-pages && git push origin gh-pages && break
           echo "Push attempt $i failed, retrying in $((i * 5))s..."
@@ -103,4 +107,3 @@ jobs:
         files: |
             vstar-bash.zip
             vstar-win.zip
-            plugin/vstar-plugins.zip

--- a/.github/workflows/stable-plugin-release.yml
+++ b/.github/workflows/stable-plugin-release.yml
@@ -1,0 +1,70 @@
+# This workflow builds the VStar plugins for a stable release and deploys
+# them to gh-pages under plugins/<version>/.
+#
+# Triggered by pushing a version tag of the form <major>.<minor>.<patch>,
+# e.g. git tag 2.25.0 && git push origin 2.25.0
+# Can also be triggered manually via workflow_dispatch with a version input.
+#
+# See: https://github.com/AAVSO/VStar/issues/589
+
+name: Stable Plugin Release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    name: Stable plugin release
+
+    permissions:
+      contents: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Java
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+    - name: Get version
+      id: version
+      run: echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+    - name: Create plugin dir
+      run: mkdir -p ~/vstar_plugins
+    - name: Create plugin libs dir
+      run: mkdir -p ~/vstar_plugin_libs
+    - name: Build plugins archive
+      run: |
+        cd plugin
+        ant -noinput -buildfile build.xml aavso
+    - name: Checkout gh-pages
+      uses: actions/checkout@v4
+      with:
+        ref: gh-pages
+        path: _site
+    - name: Deploy plugins to gh-pages
+      run: |
+        VERSION=${{ steps.version.outputs.version }}
+        mkdir -p _site/plugins/$VERSION
+        unzip -q plugin/vstar-plugins.zip -d _site/plugins/$VERSION/
+    - name: Commit and push plugins to gh-pages
+      working-directory: _site
+      run: |
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git config user.name "github-actions[bot]"
+        git add -A
+        if git diff --cached --quiet; then
+          echo "No plugin changes to publish."
+          exit 0
+        fi
+        git commit -m "Deploy plugins for ${{ steps.version.outputs.version }}"
+        for i in 1 2 3; do
+          git pull --rebase origin gh-pages && git push origin gh-pages && break
+          echo "Push attempt $i failed, retrying in $((i * 5))s..."
+          sleep $((i * 5))
+        done

--- a/src/org/aavso/tools/vstar/ui/dialog/plugin/manager/PluginManager.java
+++ b/src/org/aavso/tools/vstar/ui/dialog/plugin/manager/PluginManager.java
@@ -50,7 +50,7 @@ import org.aavso.tools.vstar.util.Pair;
  */
 public class PluginManager {
 
-	public final static String DEFAULT_PLUGIN_BASE_URL_STR = "https://archive.aavso.org/sites/default/files/vstar-plugins/vstar-plugins-"
+	public final static String DEFAULT_PLUGIN_BASE_URL_STR = "https://aavso.github.io/VStar/plugins/"
 			+ ResourceAccessor.getVersionString();
 
 	// public final static String DEFAULT_PLUGIN_BASE_URL_STR =


### PR DESCRIPTION
- Update PluginManager default plugin base URL from archive.aavso.org to https://aavso.github.io/VStar/plugins/<version>
- snapshot-release.yml: unzip plugin archive to plugins/snapshot/ on gh-pages on every master push; remove plugin zip from release assets
- Add stable-plugin-release.yml: deploys plugins to plugins/<version>/ on gh-pages, triggered by version tag push or manual workflow_dispatch (select the tag from the branch/tag picker to build from that ref)