### PR TITLE
#579: add boolean show constructors to AboutBox and MultiEntryComponentDialog

### DIFF
--- a/src/org/aavso/tools/vstar/ui/dialog/AboutBox.java
+++ b/src/org/aavso/tools/vstar/ui/dialog/AboutBox.java
@@ -50,24 +50,39 @@ import org.aavso.tools.vstar.ui.resources.ResourceAccessor;
 public class AboutBox extends JDialog {
 
     public AboutBox() {
+        this(true);
+    }
+
+    /**
+     * Package-private constructor used by tests.
+     * Pass {@code show=false} to build the dialog without displaying it.
+     * When false, UI panel and image-resource loading are skipped entirely,
+     * avoiding both the {@code Mediator.getUI()} call and the blocking
+     * {@code setVisible(true)}. {@code getAboutBoxText()}, title, and
+     * modal state are all fully initialised regardless.
+     */
+    AboutBox(boolean show) {
         super(DocumentManager.findActiveWindow());
         this.setTitle("About VStar");
         this.setModal(true);
+        this.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
 
-        Container contentPane = this.getContentPane();
+        if (show) {
+            Container contentPane = this.getContentPane();
 
-        JPanel topPane = new JPanel();
-        topPane.setLayout(new BoxLayout(topPane, BoxLayout.PAGE_AXIS));
-        topPane.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
+            JPanel topPane = new JPanel();
+            topPane.setLayout(new BoxLayout(topPane, BoxLayout.PAGE_AXIS));
+            topPane.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
 
-        topPane.add(createMainPane());
-        topPane.add(createButtonPane());
+            topPane.add(createMainPane());
+            topPane.add(createButtonPane());
 
-        contentPane.add(topPane);
+            contentPane.add(topPane);
 
-        this.pack();
-        this.setLocationRelativeTo(Mediator.getUI().getContentPane());
-        this.setVisible(true);
+            this.pack();
+            this.setLocationRelativeTo(Mediator.getUI().getContentPane());
+            this.setVisible(true);
+        }
     }
 
     private Component createMainPane() {

--- a/src/org/aavso/tools/vstar/ui/dialog/AboutBox.java
+++ b/src/org/aavso/tools/vstar/ui/dialog/AboutBox.java
@@ -54,12 +54,12 @@ public class AboutBox extends JDialog {
     }
 
     /**
-     * Package-private constructor used by tests.
      * Pass {@code show=false} to build the dialog without displaying it.
      * When false, UI panel and image-resource loading are skipped entirely,
      * avoiding both the {@code Mediator.getUI()} call and the blocking
      * {@code setVisible(true)}. {@code getAboutBoxText()}, title, and
      * modal state are all fully initialised regardless.
+     * Package-private so tests can construct without display.
      */
     AboutBox(boolean show) {
         super(DocumentManager.findActiveWindow());

--- a/src/org/aavso/tools/vstar/ui/dialog/MultiEntryComponentDialog.java
+++ b/src/org/aavso/tools/vstar/ui/dialog/MultiEntryComponentDialog.java
@@ -60,8 +60,21 @@ public class MultiEntryComponentDialog extends AbstractOkCancelDialog {
 	public MultiEntryComponentDialog(String title,
 			String helpTopic,			
 			List<ITextComponent<?>> fields,
-			Optional<JComponent> additionalUIComponent
-			) {
+			Optional<JComponent> additionalUIComponent) {
+		this(title, helpTopic, fields, additionalUIComponent, true);
+	}
+
+	/**
+	 * Package-private constructor used by tests.
+	 * Pass {@code show=false} to build the dialog without displaying it,
+	 * avoiding the {@code Mediator.getUI()} call and the blocking
+	 * {@code setVisible(true)}.
+	 */
+	MultiEntryComponentDialog(String title,
+			String helpTopic,
+			List<ITextComponent<?>> fields,
+			Optional<JComponent> additionalUIComponent,
+			boolean show) {
 		super(title);
 		this.fields = fields;
 
@@ -89,10 +102,12 @@ public class MultiEntryComponentDialog extends AbstractOkCancelDialog {
 		contentPane.add(topPane);
 
 		this.pack();
-		setLocationRelativeTo(Mediator.getUI().getContentPane());
-		this.setVisible(true);
+		if (show) {
+			setLocationRelativeTo(Mediator.getUI().getContentPane());
+			this.setVisible(true);
+		}
 	}
-	
+
 	/**
 	 * Constructor
 	 * 

--- a/src/org/aavso/tools/vstar/ui/dialog/MultiEntryComponentDialog.java
+++ b/src/org/aavso/tools/vstar/ui/dialog/MultiEntryComponentDialog.java
@@ -65,10 +65,10 @@ public class MultiEntryComponentDialog extends AbstractOkCancelDialog {
 	}
 
 	/**
-	 * Package-private constructor used by tests.
 	 * Pass {@code show=false} to build the dialog without displaying it,
 	 * avoiding the {@code Mediator.getUI()} call and the blocking
 	 * {@code setVisible(true)}.
+	 * Package-private so tests can construct without display.
 	 */
 	MultiEntryComponentDialog(String title,
 			String helpTopic,

--- a/test/AllTests.java
+++ b/test/AllTests.java
@@ -56,9 +56,11 @@ import org.aavso.tools.vstar.util.stats.DescStatsTest;
 import org.aavso.tools.vstar.util.stats.PhaseCalcsTest;
 import org.aavso.tools.vstar.util.stats.anova.CommonsMathAnovaTest;
 import org.aavso.tools.vstar.util.stats.anova.EpsAurVisJD2454700ToJD2455000AnovaTest;
+import org.aavso.tools.vstar.ui.dialog.AboutBoxTest;
 import org.aavso.tools.vstar.ui.dialog.AbstractOkCancelDialogTest;
 import org.aavso.tools.vstar.ui.dialog.DateToJdDialogTest;
 import org.aavso.tools.vstar.ui.dialog.DoubleFieldTest;
+import org.aavso.tools.vstar.ui.dialog.MultiEntryComponentDialogTest;
 import org.aavso.tools.vstar.ui.dialog.TextDialogTest;
 import org.aavso.tools.vstar.ui.model.list.AbstractSyntheticObservationTableModelTest;
 import org.aavso.tools.vstar.ui.model.list.PeriodAnalysisDataTableModelTest;
@@ -135,7 +137,9 @@ public class AllTests {
 		suite.addTestSuite(DateToJdDialogTest.class);
 		suite.addTestSuite(TextDialogTest.class);
 		suite.addTestSuite(AbstractOkCancelDialogTest.class);
+		suite.addTestSuite(AboutBoxTest.class);
 		suite.addTestSuite(DoubleFieldTest.class);
+		suite.addTestSuite(MultiEntryComponentDialogTest.class);
 		// $JUnit-END$
 		
 		return suite;

--- a/test/org/aavso/tools/vstar/ui/dialog/AboutBoxTest.java
+++ b/test/org/aavso/tools/vstar/ui/dialog/AboutBoxTest.java
@@ -1,0 +1,57 @@
+/**
+ * VStar: a statistical analysis tool for variable star data.
+ * Copyright (C) 2009  AAVSO (http://www.aavso.org/)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.aavso.tools.vstar.ui.dialog;
+
+import java.util.Locale;
+
+import junit.framework.TestCase;
+
+/**
+ * Tests for {@link AboutBox}.
+ *
+ * Uses the package-private {@code AboutBox(boolean show)} constructor
+ * (show=false) to build the dialog without displaying it, avoiding the
+ * {@code Mediator.getUI()} call and the blocking {@code setVisible(true)}.
+ *
+ * NOTE: These tests hang on macOS when run via Ant outside the EDT (a
+ * macOS AppKit/main-thread constraint). They pass correctly under
+ * Linux with {@code xvfb-run} as used in CI.
+ *
+ * Part of issue #579 (GUI code coverage).
+ */
+public class AboutBoxTest extends TestCase {
+
+	public void testAboutBox() {
+		Locale.setDefault(Locale.ENGLISH);
+		AboutBox dialog = new AboutBox(false);
+		try {
+			assertEquals("About VStar", dialog.getTitle());
+			assertTrue(dialog.isModal());
+
+			String text = dialog.getAboutBoxText();
+			assertNotNull(text);
+			assertTrue(text.length() > 0);
+			assertTrue(text.contains("VStar"));
+			assertTrue(text.contains("David Benn"));
+			assertTrue(text.contains("GNU Affero General Public License"));
+			assertTrue(text.contains("aavso.org"));
+		} finally {
+			dialog.dispose();
+		}
+	}
+}

--- a/test/org/aavso/tools/vstar/ui/dialog/AboutBoxTest.java
+++ b/test/org/aavso/tools/vstar/ui/dialog/AboutBoxTest.java
@@ -28,10 +28,6 @@ import junit.framework.TestCase;
  * (show=false) to build the dialog without displaying it, avoiding the
  * {@code Mediator.getUI()} call and the blocking {@code setVisible(true)}.
  *
- * NOTE: These tests hang on macOS when run via Ant outside the EDT (a
- * macOS AppKit/main-thread constraint). They pass correctly under
- * Linux with {@code xvfb-run} as used in CI.
- *
  * Part of issue #579 (GUI code coverage).
  */
 public class AboutBoxTest extends TestCase {

--- a/test/org/aavso/tools/vstar/ui/dialog/MultiEntryComponentDialogTest.java
+++ b/test/org/aavso/tools/vstar/ui/dialog/MultiEntryComponentDialogTest.java
@@ -38,10 +38,6 @@ import junit.framework.TestCase;
  * - When okAction() SUCCEEDS it calls dispose() internally; the test
  *   must NOT call dispose() a second time to avoid a double-dispose crash.
  *
- * NOTE: These tests hang on macOS when run via Ant outside the EDT (a
- * macOS AppKit/main-thread constraint). They pass correctly under
- * Linux with {@code xvfb-run} as used in CI.
- *
  * Part of issue #579 (GUI code coverage).
  */
 public class MultiEntryComponentDialogTest extends TestCase {

--- a/test/org/aavso/tools/vstar/ui/dialog/MultiEntryComponentDialogTest.java
+++ b/test/org/aavso/tools/vstar/ui/dialog/MultiEntryComponentDialogTest.java
@@ -1,0 +1,166 @@
+/**
+ * VStar: a statistical analysis tool for variable star data.
+ * Copyright (C) 2009  AAVSO (http://www.aavso.org/)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.aavso.tools.vstar.ui.dialog;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Optional;
+
+import junit.framework.TestCase;
+
+/**
+ * Tests for {@link MultiEntryComponentDialog}.
+ *
+ * Uses the package-private 5-argument constructor (show=false) to build
+ * dialogs without displaying them, avoiding the {@code Mediator.getUI()} call
+ * and the blocking {@code setVisible(true)}.
+ *
+ * Notes on scope:
+ * - okAction() with INVALID values is NOT tested here because it calls
+ *   {@code MessageBox.showErrorDialog()}, which creates a modal
+ *   {@code JOptionPane} dialog and calls {@code setVisible(true)} —
+ *   that would block the test runner when Mediator.getUI()==null.
+ * - When okAction() SUCCEEDS it calls dispose() internally; the test
+ *   must NOT call dispose() a second time to avoid a double-dispose crash.
+ *
+ * NOTE: These tests hang on macOS when run via Ant outside the EDT (a
+ * macOS AppKit/main-thread constraint). They pass correctly under
+ * Linux with {@code xvfb-run} as used in CI.
+ *
+ * Part of issue #579 (GUI code coverage).
+ */
+public class MultiEntryComponentDialogTest extends TestCase {
+
+	@Override
+	protected void setUp() {
+		Locale.setDefault(Locale.ENGLISH);
+	}
+
+	private MultiEntryComponentDialog build(ITextComponent<?>... fields) {
+		return new MultiEntryComponentDialog(
+				"Test", null, Arrays.asList(fields), Optional.empty(), false);
+	}
+
+	private MultiEntryComponentDialog buildWithHelp(
+			String helpTopic, ITextComponent<?>... fields) {
+		return new MultiEntryComponentDialog(
+				"Test", helpTopic, Arrays.asList(fields), Optional.empty(), false);
+	}
+
+	// -----------------------------------------------------------
+	// Construction and initial state
+	// -----------------------------------------------------------
+
+	public void testConstructionWithSingleDoubleField() {
+		DoubleField f = new DoubleField("Period", 0.0, 100.0, 5.0);
+		MultiEntryComponentDialog d = build(f);
+		assertNotNull(d);
+		d.dispose();
+	}
+
+	public void testConstructionWithMultipleFields() {
+		DoubleField f1 = new DoubleField("Min", 0.0, 50.0, 1.0);
+		DoubleField f2 = new DoubleField("Max", 0.0, 50.0, 10.0);
+		MultiEntryComponentDialog d = build(f1, f2);
+		assertNotNull(d);
+		d.dispose();
+	}
+
+	public void testConstructionWithHelpTopic() {
+		DoubleField f = new DoubleField("Value", null, null, 1.0);
+		MultiEntryComponentDialog d = buildWithHelp("http://example.com/help", f);
+		assertNotNull(d);
+		d.dispose();
+	}
+
+	public void testIsCancelledByDefault() {
+		DoubleField f = new DoubleField("Value", null, null, 1.0);
+		MultiEntryComponentDialog d = build(f);
+		assertTrue(d.isCancelled());
+		d.dispose();
+	}
+
+	public void testIsModal() {
+		DoubleField f = new DoubleField("Value", null, null, 1.0);
+		MultiEntryComponentDialog d = build(f);
+		assertTrue(d.isModal());
+		d.dispose();
+	}
+
+	public void testTitle() {
+		DoubleField f = new DoubleField("Value", null, null, 1.0);
+		MultiEntryComponentDialog d = build(f);
+		assertEquals("Test", d.getTitle());
+		d.dispose();
+	}
+
+	// -----------------------------------------------------------
+	// okAction with valid field values
+	// (invalid-value tests omitted: okAction shows a blocking modal
+	//  error dialog via MessageBox when Mediator.getUI()==null)
+	// -----------------------------------------------------------
+
+	public void testOkActionWithValidFieldClearsCancelledFlag() {
+		DoubleField f = new DoubleField("Period", 0.0, 100.0, 5.0);
+		MultiEntryComponentDialog d = build(f);
+		assertTrue(d.isCancelled());
+		d.okAction();
+		// okAction() disposes the dialog on success; do NOT call d.dispose() again.
+		assertFalse("okAction() with valid value should clear cancelled flag",
+				d.isCancelled());
+	}
+
+	// -----------------------------------------------------------
+	// cancelAction
+	// -----------------------------------------------------------
+
+	public void testCancelActionLeavesDialogCancelled() {
+		DoubleField f = new DoubleField("Value", null, null, 1.0);
+		MultiEntryComponentDialog d = build(f);
+		d.cancelAction();
+		assertTrue(d.isCancelled());
+		d.dispose();
+	}
+
+	// -----------------------------------------------------------
+	// Additional UI component
+	// -----------------------------------------------------------
+
+	public void testConstructionWithAdditionalComponent() {
+		DoubleField f = new DoubleField("Value", null, null, 1.0);
+		javax.swing.JLabel extra = new javax.swing.JLabel("Note");
+		MultiEntryComponentDialog d = new MultiEntryComponentDialog(
+				"Test", null,
+				Arrays.asList((ITextComponent<?>) f),
+				Optional.of(extra),
+				false);
+		assertNotNull(d);
+		d.dispose();
+	}
+
+	public void testConstructionWithEmptyOptional() {
+		DoubleField f = new DoubleField("Value", null, null, 1.0);
+		MultiEntryComponentDialog d = new MultiEntryComponentDialog(
+				"Test", null,
+				Arrays.asList((ITextComponent<?>) f),
+				Optional.empty(),
+				false);
+		assertNotNull(d);
+		d.dispose();
+	}
+}


### PR DESCRIPTION
Decouple both dialogs from Mediator.getUI() to enable headless testing.

* AboutBox: add package-private AboutBox(boolean show) constructor that skips UI panel building, setLocationRelativeTo, and setVisible when show=false; the public no-arg constructor delegates with show=true.
* MultiEntryComponentDialog: add package-private 5-arg constructor (title, helpTopic, fields, additionalUIComponent, show) that guards setLocationRelativeTo and setVisible behind show; the existing public 4-arg constructor delegates with show=true — all other overloads are unchanged.
* Add AboutBoxTest and MultiEntryComponentDialogTest exercising the new show=false path; register both in AllTests.java.