### PR TITLE
Expand plugin and external.lib test coverage (#606)

### DIFF
--- a/plugin/build.xml
+++ b/plugin/build.xml
@@ -145,11 +145,7 @@
 
 			<test name="${testcase}" todir="${test_report}" if="testcase" />
 
-			<batchtest todir="${test_report}" unless="testcase">
-				<fileset dir="${test_build}">
-					<include name="**/PluginTest.class" />
-				</fileset>
-			</batchtest>
+			<test name="org.aavso.tools.vstar.external.plugin.AllTests" todir="${test_report}" unless="testcase" />
 
 			<classpath refid="test.classpath" />
 		</junit>
@@ -199,11 +195,7 @@
 
 				<jvmarg value="-ea" />
 
-				<batchtest todir="${test_report}" unless="testcase">
-					<fileset dir="${test_build}">
-						<include name="**/PluginTest.class" />
-					</fileset>
-				</batchtest>
+				<test name="org.aavso.tools.vstar.external.plugin.AllTests" todir="${test_report}" unless="testcase" />
 
 				<classpath refid="test.classpath" />
 			</junit>

--- a/plugin/src/org/aavso/tools/vstar/external/lib/FitsTestData.java
+++ b/plugin/src/org/aavso/tools/vstar/external/lib/FitsTestData.java
@@ -1,0 +1,83 @@
+/**
+ * VStar: a statistical analysis tool for variable star data.
+ * Copyright (C) 2009  AAVSO (http://www.aavso.org/)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.aavso.tools.vstar.external.lib;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import nom.tam.fits.BinaryTableHDU;
+import nom.tam.fits.Fits;
+import nom.tam.fits.FitsException;
+import nom.tam.fits.ImageHDU;
+
+/**
+ * Builds minimal in-memory FITS files for plugin self-tests.
+ */
+public final class FitsTestData {
+
+    private FitsTestData() {
+    }
+
+    /**
+     * Lightkurve-style FITS with Kepler telescope metadata and one valid row.
+     */
+    public static byte[] createLightKurveKeplerFits() throws FitsException, IOException {
+        return createFits("Kepler", new String[] { "TIME", "FLUX", "FLUX_ERR" },
+                new Object[] { new double[] { 0.5 }, new float[] { 1000f }, new float[] { 10f } },
+                null, null);
+    }
+
+    /**
+     * Kepler/TESS archive-style FITS with PDCSAP columns (corrected flux).
+     */
+    public static byte[] createKeplerArchiveFits() throws FitsException, IOException {
+        String[] names = { "TIME", "COL1", "COL2", "SAP_FLUX", "SAP_FLUX_ERR", "COL5", "COL6",
+                "PDCSAP_FLUX", "PDCSAP_FLUX_ERR", "QUALITY" };
+        Object[] cols = { new double[] { 0.5 }, new float[] { 0f }, new float[] { 0f },
+                new float[] { 1000f }, new float[] { 10f }, new float[] { 0f }, new float[] { 0f },
+                new float[] { 1000f }, new float[] { 10f }, new int[] { 0 } };
+        return createFits("Kepler", names, cols, 2454833, 0.0);
+    }
+
+    private static byte[] createFits(String telescope, String[] columnNames, Object[] columns,
+            Integer bjdRefInt, Double bjdRefFrac) throws FitsException, IOException {
+        Fits fits = new Fits();
+
+        nom.tam.fits.Data imageData = ImageHDU.encapsulate(new double[1][1]);
+        ImageHDU image = new ImageHDU(ImageHDU.manufactureHeader(imageData), imageData);
+        image.getHeader().addValue("TELESCOP", telescope, "");
+        image.getHeader().addValue("OBJECT", "TEST", "");
+        fits.addHDU(image);
+
+        nom.tam.fits.Data tableData = BinaryTableHDU.encapsulate(columns);
+        BinaryTableHDU table = new BinaryTableHDU(BinaryTableHDU.manufactureHeader(tableData), tableData);
+        for (int i = 0; i < columnNames.length; i++) {
+            table.setColumnName(i, columnNames[i], "");
+        }
+        if (bjdRefInt != null && bjdRefFrac != null) {
+            table.getHeader().addValue("BJDREFI", bjdRefInt.longValue(), "");
+            table.getHeader().addValue("BJDREFF", bjdRefFrac.doubleValue(), "");
+        }
+        fits.addHDU(table);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        fits.write(new DataOutputStream(out));
+        return out.toByteArray();
+    }
+}

--- a/plugin/src/org/aavso/tools/vstar/external/lib/GaiaObSourceBase.java
+++ b/plugin/src/org/aavso/tools/vstar/external/lib/GaiaObSourceBase.java
@@ -34,7 +34,9 @@ package org.aavso.tools.vstar.external.lib;
 
 import java.awt.Color;
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -56,6 +58,7 @@ import org.aavso.tools.vstar.exception.ObservationReadError;
 import org.aavso.tools.vstar.exception.ObservationValidationError;
 import org.aavso.tools.vstar.input.AbstractObservationRetriever;
 import org.aavso.tools.vstar.plugin.ObservationSourcePluginBase;
+import org.aavso.tools.vstar.util.Tolerance;
 
 public abstract class GaiaObSourceBase extends ObservationSourcePluginBase {
 
@@ -780,6 +783,77 @@ public abstract class GaiaObSourceBase extends ObservationSourcePluginBase {
 		public String getSourceType() {
 			return "Gaia DR2/DR3 Format";
 		}
+	}
+
+	@Override
+	public Boolean test() {
+		setTestMode(true);
+		paramIgnoreFlags = true;
+		paramGaiaRelease = GaiaRelease.DR2;
+
+		boolean success = true;
+		try {
+			success &= runGaiaFileTest(false);
+			success &= runGaiaFileTest(true);
+		} catch (Exception e) {
+			success = false;
+		} finally {
+			setTestMode(false);
+		}
+		return success;
+	}
+
+	private boolean runGaiaFileTest(boolean transform) throws Exception {
+		paramTransform = transform;
+
+		String header = "source_id,transit_id,band,time,mag,flux,flux_error,flux_over_error,rejected_by_photometry,rejected_by_variability,other_flags,solution_id\n";
+		String[] lines;
+		if (transform) {
+			lines = new String[] {
+					header,
+					"1951343009975999744,1,BP,1000.0,11.0,1000.0,10.0,,FALSE,FALSE,0,1\n",
+					"1951343009975999744,1,G,1000.0,10.0,1000.0,10.0,,FALSE,FALSE,0,1\n",
+					"1951343009975999744,1,RP,1000.0,12.0,1000.0,10.0,,FALSE,FALSE,0,1\n" };
+		} else {
+			lines = new String[] {
+					header,
+					"1951343009975999744,1,G,1000.0,10.0,1000.0,10.0,,FALSE,FALSE,0,1\n" };
+		}
+
+		StringBuffer content = new StringBuffer();
+		for (String line : lines) {
+			content.append(line);
+		}
+		InputStream in = new ByteArrayInputStream(content.toString().getBytes());
+		List<InputStream> streams = new ArrayList<InputStream>();
+		streams.add(in);
+		setInputInfo(streams, "Gaia test");
+
+		GAIADR2FormatRetriever retriever = new GAIADR2FormatRetriever(transform, true, GaiaRelease.DR2);
+		retriever.getNumberOfRecords();
+		retriever.retrieveObservations();
+
+		List<ValidObservation> gaiaObs = retriever.getValidObservations();
+		if (!transform) {
+			boolean success = 1 == gaiaObs.size();
+			ValidObservation ob = gaiaObs.get(0);
+			success &= gaiaGseries == ob.getBand();
+			success &= Tolerance.areClose(2456197.5, ob.getJD(), 1e-6, true);
+			success &= Tolerance.areClose(10.0, ob.getMag(), 1e-6, true);
+			success &= "GaiaDR2 1951343009975999744".equals(ob.getName());
+			success &= JDflavour.BJD == ob.getJDflavour();
+			return success;
+		}
+
+		boolean success = 3 == gaiaObs.size();
+		success &= SeriesType.Johnson_V == gaiaObs.get(0).getBand();
+		success &= SeriesType.Cousins_R == gaiaObs.get(1).getBand();
+		success &= SeriesType.Cousins_I == gaiaObs.get(2).getBand();
+		for (ValidObservation ob : gaiaObs) {
+			success &= ob.isTransformed();
+			success &= Tolerance.areClose(2456197.5, ob.getJD(), 1e-6, true);
+		}
+		return success;
 	}
 
 }

--- a/plugin/src/org/aavso/tools/vstar/external/lib/ZTFObSourceBase.java
+++ b/plugin/src/org/aavso/tools/vstar/external/lib/ZTFObSourceBase.java
@@ -19,8 +19,11 @@ package org.aavso.tools.vstar.external.lib;
 
 import java.awt.Color;
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.Locale;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -42,6 +45,7 @@ import org.aavso.tools.vstar.exception.ObservationReadError;
 import org.aavso.tools.vstar.exception.ObservationValidationError;
 import org.aavso.tools.vstar.input.AbstractObservationRetriever;
 import org.aavso.tools.vstar.plugin.ObservationSourcePluginBase;
+import org.aavso.tools.vstar.util.Tolerance;
 
 /**
  * 
@@ -319,6 +323,51 @@ public abstract class ZTFObSourceBase extends ObservationSourcePluginBase {
 		public String getSourceType() {
 			return "ZTF Format";
 		}
+	}
+
+	@Override
+	public Boolean test() {
+		setTestMode(true);
+
+		String[] lines = {
+				"oid\thjd\tmag\tmagerr\tcatflags\tfiltercode\texptime\tairmass\n",
+				"12345\t2458000.5\t12.5\t0.01\t0\tzg\t30\t1.2\n" };
+
+		boolean success = true;
+
+		try {
+			StringBuffer content = new StringBuffer();
+			for (String line : lines) {
+				content.append(line);
+			}
+			InputStream in = new ByteArrayInputStream(content.toString().getBytes());
+			List<InputStream> streams = new ArrayList<InputStream>();
+			streams.add(in);
+			setInputInfo(streams, "ZTF test");
+
+			ZTFFormatRetriever retriever = new ZTFFormatRetriever();
+			retriever.getNumberOfRecords();
+			retriever.retrieveObservations();
+
+			List<ValidObservation> ztfObs = retriever.getValidObservations();
+			success &= 1 == ztfObs.size();
+
+			ValidObservation ob = ztfObs.get(0);
+			success &= "12345".equals(ob.getName());
+			success &= Tolerance.areClose(2458000.5, ob.getJD(), 1e-6, true);
+			success &= Tolerance.areClose(12.5, ob.getMag(), 1e-6, true);
+			success &= Tolerance.areClose(0.01, ob.getMagnitude().getUncertainty(), 1e-6, true);
+			success &= ztfgSeries == ob.getBand();
+			success &= JDflavour.HJD == ob.getJDflavour();
+			success &= String.format(Locale.ENGLISH, "ZTF object %s", "12345")
+					.equals(retriever.getSourceName());
+		} catch (Exception e) {
+			success = false;
+		} finally {
+			setTestMode(false);
+		}
+
+		return success;
 	}
 
 }

--- a/plugin/src/org/aavso/tools/vstar/external/plugin/FlexibleTextFileFormatObservationSource.java
+++ b/plugin/src/org/aavso/tools/vstar/external/plugin/FlexibleTextFileFormatObservationSource.java
@@ -884,4 +884,42 @@ public class FlexibleTextFileFormatObservationSource extends
 		}
 
 	}
+
+	@Override
+	public Boolean test() {
+		setTestMode(true);
+		String[] lines = {
+				"#FIELDS=time,mag,magerr\n",
+				"#DELIM=comma\n",
+				"#DATE=JD\n",
+				"2450000,5.0,0.01\n" };
+
+		boolean success = true;
+		try {
+			StringBuffer content = new StringBuffer();
+			for (String line : lines) {
+				content.append(line);
+			}
+			java.io.InputStream in = new java.io.ByteArrayInputStream(content.toString().getBytes());
+			java.util.List<java.io.InputStream> streams = new java.util.ArrayList<java.io.InputStream>();
+			streams.add(in);
+			setInputInfo(streams, "flex test");
+
+			AbstractObservationRetriever retriever = getObservationRetriever();
+			retriever.getNumberOfRecords();
+			retriever.retrieveObservations();
+
+			success &= 1 == retriever.getValidObservations().size();
+			ValidObservation ob = retriever.getValidObservations().get(0);
+			success &= 2450000 == ob.getJD();
+			success &= 5.0 == ob.getMag();
+			success &= 0.01 == ob.getMagnitude().getUncertainty();
+			success &= JDflavour.JD == ob.getJDflavour();
+		} catch (Exception e) {
+			success = false;
+		} finally {
+			setTestMode(false);
+		}
+		return success;
+	}
 }

--- a/plugin/src/org/aavso/tools/vstar/external/plugin/HipparcosObservationSource.java
+++ b/plugin/src/org/aavso/tools/vstar/external/plugin/HipparcosObservationSource.java
@@ -30,6 +30,7 @@ import org.aavso.tools.vstar.exception.ObservationReadError;
 import org.aavso.tools.vstar.input.AbstractObservationRetriever;
 import org.aavso.tools.vstar.plugin.InputType;
 import org.aavso.tools.vstar.plugin.ObservationSourcePluginBase;
+import org.aavso.tools.vstar.util.Tolerance;
 //12/02/2018 C. Kotnik added name to observations so they can be
 //saved and reloaded from a file.
 /**
@@ -207,6 +208,26 @@ public class HipparcosObservationSource extends ObservationSourcePluginBase {
 				addInvalidObservation(ob);
 			}
 			return line;
+		}
+	}
+
+	@Override
+	public Boolean test() {
+		setTestMode(true);
+		try {
+			String[] lines = { "JD\n", "10000|10.0|0|0\n" };
+			AbstractObservationRetriever retriever = getTestRetriever(lines, "HIP test");
+			if (retriever.getValidObservations().size() != 1) {
+				return false;
+			}
+			ValidObservation ob = retriever.getValidObservations().get(0);
+			// Epoch field is HT1-style offset: sample 10000 -> BJD 2450000 with this reader
+			return Tolerance.areClose(2450000.0, ob.getJD(), 1e-6, true)
+					&& Tolerance.areClose(10.0, ob.getMag(), 1e-6, true);
+		} catch (Exception e) {
+			return false;
+		} finally {
+			setTestMode(false);
 		}
 	}
 }

--- a/plugin/src/org/aavso/tools/vstar/external/plugin/JulianDateObservationsFilter.java
+++ b/plugin/src/org/aavso/tools/vstar/external/plugin/JulianDateObservationsFilter.java
@@ -17,8 +17,11 @@
  */
 package org.aavso.tools.vstar.external.plugin;
 
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 
+import org.aavso.tools.vstar.data.Magnitude;
 import org.aavso.tools.vstar.data.ValidObservation;
 import org.aavso.tools.vstar.data.ValidObservation.JDflavour;
 import org.aavso.tools.vstar.plugin.CustomFilterPluginBase;
@@ -53,6 +56,36 @@ public class JulianDateObservationsFilter extends CustomFilterPluginBase {
 	@Override
 	public String getDocName() {
 		return "https://github.com/AAVSO/VStar/wiki/Custom-Filter-Plug%E2%80%90ins#julian-date-observations-filter";
+	}
+
+	@Override
+	public Boolean test() {
+		setTestMode(true);
+
+		List<ValidObservation> obs = new ArrayList<ValidObservation>();
+
+		ValidObservation jdOb = new ValidObservation();
+		jdOb.setJD(2450000);
+		jdOb.setMagnitude(new Magnitude(5, 0));
+		jdOb.setJDflavour(JDflavour.JD);
+		obs.add(jdOb);
+
+		ValidObservation bjdOb = new ValidObservation();
+		bjdOb.setJD(2450001);
+		bjdOb.setMagnitude(new Magnitude(6, 0));
+		bjdOb.setJDflavour(JDflavour.BJD);
+		obs.add(bjdOb);
+
+		filteredObs = new LinkedHashSet<ValidObservation>();
+		Pair<String, String> idPair = filter(obs);
+
+		boolean success = filteredObs.size() == 1;
+		success &= filteredObs.contains(jdOb);
+		success &= "Julian Date Observations".equals(idPair.first);
+		success &= "Julian Date Observations".equals(idPair.second);
+
+		setTestMode(false);
+		return success;
 	}
 
 }

--- a/plugin/src/org/aavso/tools/vstar/external/plugin/KeplerFITSObservationSource.java
+++ b/plugin/src/org/aavso/tools/vstar/external/plugin/KeplerFITSObservationSource.java
@@ -19,6 +19,8 @@ package org.aavso.tools.vstar.external.plugin;
 
 import java.awt.Color;
 import java.awt.Container;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -30,7 +32,10 @@ import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 
 import org.aavso.tools.vstar.data.SeriesType;
+import org.aavso.tools.vstar.data.ValidObservation;
+import org.aavso.tools.vstar.external.lib.FitsTestData;
 import org.aavso.tools.vstar.external.lib.TESSObservationRetrieverBase;
+import org.aavso.tools.vstar.util.Tolerance;
 import org.aavso.tools.vstar.input.AbstractObservationRetriever;
 import org.aavso.tools.vstar.plugin.InputType;
 import org.aavso.tools.vstar.plugin.ObservationSourcePluginBase;
@@ -155,6 +160,10 @@ public class KeplerFITSObservationSource extends ObservationSourcePluginBase {
 
 	@Override
 	public AbstractObservationRetriever getObservationRetriever() {
+		if (inTestMode()) {
+			loadRawData = false;
+			return new KeplerFITSObservationRetriever(loadRawData);
+		}
 		// Dialog moved from retrieveObservations() where it invoked from non-UI thread
 		// to this more natural place.
 		// No annoying "No observations for the specified period" messages.
@@ -381,6 +390,35 @@ public class KeplerFITSObservationSource extends ObservationSourcePluginBase {
 				dispose();
 			}
 		}
+	}
+
+	@Override
+	public Boolean test() {
+		setTestMode(true);
+		boolean success = true;
+		try {
+			byte[] fitsBytes = FitsTestData.createKeplerArchiveFits();
+			InputStream in = new ByteArrayInputStream(fitsBytes);
+			List<InputStream> streams = new ArrayList<InputStream>();
+			streams.add(in);
+			setInputInfo(streams, "kepler test");
+
+			KeplerFITSObservationRetriever retriever = new KeplerFITSObservationRetriever(false);
+			retriever.getNumberOfRecords();
+			retriever.retrieveObservations();
+
+			List<ValidObservation> obs = retriever.getValidObservations();
+			success &= 1 == obs.size();
+			ValidObservation ob = obs.get(0);
+			success &= dataSeriesKepler == ob.getBand();
+			success &= Tolerance.areClose(2454833.5, ob.getJD(), 1e-4, true);
+			success &= "TEST".equals(ob.getName());
+		} catch (Exception e) {
+			success = false;
+		} finally {
+			setTestMode(false);
+		}
+		return success;
 	}
 	
 }

--- a/plugin/src/org/aavso/tools/vstar/external/plugin/LightKurveFITSObservationSource.java
+++ b/plugin/src/org/aavso/tools/vstar/external/plugin/LightKurveFITSObservationSource.java
@@ -18,14 +18,19 @@
 package org.aavso.tools.vstar.external.plugin;
 
 import java.awt.Color;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.aavso.tools.vstar.data.ValidObservation;
 import org.aavso.tools.vstar.data.SeriesType;
+import org.aavso.tools.vstar.external.lib.FitsTestData;
 import org.aavso.tools.vstar.external.lib.TESSObservationRetrieverBase;
 import org.aavso.tools.vstar.input.AbstractObservationRetriever;
 import org.aavso.tools.vstar.plugin.InputType;
 import org.aavso.tools.vstar.plugin.ObservationSourcePluginBase;
+import org.aavso.tools.vstar.util.Tolerance;
 
 import nom.tam.fits.BasicHDU;
 import nom.tam.fits.BinaryTableHDU;
@@ -177,6 +182,35 @@ public class LightKurveFITSObservationSource extends ObservationSourcePluginBase
             return "Lightkurve FITS File";
         }
 
+    }
+
+    @Override
+    public Boolean test() {
+        setTestMode(true);
+        boolean success = true;
+        try {
+            byte[] fitsBytes = FitsTestData.createLightKurveKeplerFits();
+            InputStream in = new ByteArrayInputStream(fitsBytes);
+            List<InputStream> streams = new ArrayList<InputStream>();
+            streams.add(in);
+            setInputInfo(streams, "lk test");
+
+            LightKurveFITSObservationRetriever retriever = new LightKurveFITSObservationRetriever();
+            retriever.getNumberOfRecords();
+            retriever.retrieveObservations();
+
+            List<ValidObservation> obs = retriever.getValidObservations();
+            success &= 1 == obs.size();
+            ValidObservation ob = obs.get(0);
+            success &= dataSeriesLightKurveKepler == ob.getBand();
+            success &= Tolerance.areClose(2454833.5, ob.getJD(), 1e-4, true);
+            success &= "TEST".equals(ob.getName());
+        } catch (Exception e) {
+            success = false;
+        } finally {
+            setTestMode(false);
+        }
+        return success;
     }
 
 }

--- a/plugin/src/org/aavso/tools/vstar/external/plugin/NSVSObservationSource.java
+++ b/plugin/src/org/aavso/tools/vstar/external/plugin/NSVSObservationSource.java
@@ -168,4 +168,27 @@ public class NSVSObservationSource extends ObservationSourcePluginBase {
 			return str != null && "".equals(str.trim());
 		}
 	}
+
+	@Override
+	public Boolean test() {
+		setTestMode(true);
+		String[] lines = {
+				"MJD-50000\tmag\tmagerr\tflags\n",
+				"1000\t10.0\t0.01\t0\n" };
+
+		boolean success = true;
+		try {
+			AbstractObservationRetriever retriever = getTestRetriever(lines, "NSVS test");
+			success &= 1 == retriever.getValidObservations().size();
+			ValidObservation ob = retriever.getValidObservations().get(0);
+			success &= 2451000.5 == ob.getJD();
+			success &= 10.0 == ob.getMag();
+			success &= 0.01 == ob.getMagnitude().getUncertainty();
+		} catch (Exception e) {
+			success = false;
+		} finally {
+			setTestMode(false);
+		}
+		return success;
+	}
 }

--- a/plugin/src/org/aavso/tools/vstar/external/plugin/VeLaObservationTransformer.java
+++ b/plugin/src/org/aavso/tools/vstar/external/plugin/VeLaObservationTransformer.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import org.aavso.tools.vstar.data.DateInfo;
 import org.aavso.tools.vstar.data.Magnitude;
 import org.aavso.tools.vstar.data.SeriesType;
 import org.aavso.tools.vstar.data.ValidObservation;
@@ -205,11 +206,72 @@ public class VeLaObservationTransformer extends ObservationTransformerPluginBase
      *         button was clicked and the VeLa code string.
      */
     private Pair<Boolean, String> invokeDialog(VeLaInterpreter vela) {
+        if (inTestMode()) {
+            return new Pair<Boolean, String>(true, "do() : list { [magnitude + 1 uncertainty] }");
+        }
+
         VeLaDialog velaDialog = new VeLaDialog("Define VeLa function: do():list");
 
         boolean ok = !velaDialog.isCancelled();
         String code = velaDialog.getCode();
 
         return new Pair<Boolean, String>(ok, code);
+    }
+
+    @Override
+    public Boolean test() {
+        setTestMode(true);
+
+        ValidObservation ob = new ValidObservation();
+        ob.setDateInfo(new DateInfo(2450000));
+        ob.setMagnitude(new Magnitude(5.0, 0.01));
+        ob.setBand(SeriesType.Visual);
+
+        TestSeriesInfo provider = new TestSeriesInfo(ob);
+        IUndoableAction action = createAction(provider, provider.getVisibleSeries());
+
+        boolean success = action.execute(UndoableActionType.DO);
+        success &= 6.0 == ob.getMag();
+        success &= 0.01 == ob.getMagnitude().getUncertainty();
+
+        setTestMode(false);
+        return success;
+    }
+
+    private static class TestSeriesInfo implements ISeriesInfoProvider {
+        private final Set<SeriesType> series;
+        private final List<ValidObservation> obs;
+
+        TestSeriesInfo(ValidObservation ob) {
+            series = new java.util.HashSet<SeriesType>();
+            series.add(SeriesType.Visual);
+            obs = new ArrayList<ValidObservation>();
+            obs.add(ob);
+        }
+
+        @Override
+        public Set<SeriesType> getVisibleSeries() {
+            return series;
+        }
+
+        @Override
+        public int getSeriesCount() {
+            return series.size();
+        }
+
+        @Override
+        public Set<SeriesType> getSeriesKeys() {
+            return series;
+        }
+
+        @Override
+        public boolean seriesExists(SeriesType type) {
+            return series.contains(type);
+        }
+
+        @Override
+        public List<ValidObservation> getObservations(SeriesType type) {
+            return obs;
+        }
     }
 }

--- a/plugin/test/org/aavso/tools/vstar/external/lib/ConvertHelperTest.java
+++ b/plugin/test/org/aavso/tools/vstar/external/lib/ConvertHelperTest.java
@@ -1,0 +1,94 @@
+/**
+ * VStar: a statistical analysis tool for variable star data.
+ * Copyright (C) 2009  AAVSO (http://www.aavso.org/)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.aavso.tools.vstar.external.lib;
+
+import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.List;
+
+import org.aavso.tools.vstar.ui.mediator.StarInfo;
+import org.aavso.tools.vstar.util.Pair;
+import org.aavso.tools.vstar.util.coords.DecInfo;
+import org.aavso.tools.vstar.util.coords.EpochType;
+import org.aavso.tools.vstar.util.coords.RAInfo;
+
+import com.sun.net.httpserver.HttpServer;
+
+import junit.framework.TestCase;
+
+/**
+ * Unit tests for {@link ConvertHelper}.
+ */
+public class ConvertHelperTest extends TestCase {
+
+	private String savedLocalServiceUrl;
+
+	public ConvertHelperTest(String name) {
+		super(name);
+	}
+
+	@Override
+	protected void setUp() {
+		savedLocalServiceUrl = ConvertHelper.localServiceURLstring;
+	}
+
+	@Override
+	protected void tearDown() {
+		ConvertHelper.localServiceURLstring = savedLocalServiceUrl;
+	}
+
+	public void testGetCoordinatesWhenPresent() {
+		RAInfo ra = new RAInfo(EpochType.J2000, 45.0);
+		DecInfo dec = new DecInfo(EpochType.J2000, 30.0);
+		StarInfo info = new StarInfo(null, "Test Star", null, null, null, null, null, null, ra, dec, null);
+
+		Pair<RAInfo, DecInfo> coords = ConvertHelper.getCoordinates(info);
+
+		assertNotNull(coords);
+		assertSame(ra, coords.first);
+		assertSame(dec, coords.second);
+	}
+
+	public void testAstroutilsUrlTemplate() {
+		assertTrue(ConvertHelper.URL_TEMPLATE.startsWith(ConvertHelper.ASTROUTILS_URL));
+		assertTrue(ConvertHelper.URL_TEMPLATE.contains("FUNCTION=%s"));
+	}
+
+	public void testGetConvertedListOfTimesLocalService() throws Exception {
+		HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+		int port = server.getAddress().getPort();
+		server.createContext("/convert", exchange -> {
+			byte[] response = "{\"bjd_tdb\":[2458001.5,2458002.5]}".getBytes("UTF-8");
+			exchange.getResponseHeaders().add("Content-Type", "application/json");
+			exchange.sendResponseHeaders(200, response.length);
+			exchange.getResponseBody().write(response);
+			exchange.close();
+		});
+		server.start();
+		try {
+			ConvertHelper.localServiceURLstring = "http://127.0.0.1:" + port + "/convert";
+			List<Double> times = Arrays.asList(2458000.0, 2458001.0);
+			List<Double> out = ConvertHelper.getConvertedListOfTimes(times, 45.0, 30.0, "utc2bjd");
+			assertEquals(2, out.size());
+			assertEquals(2458001.5, out.get(0), 1e-9);
+			assertEquals(2458002.5, out.get(1), 1e-9);
+		} finally {
+			server.stop(0);
+		}
+	}
+}

--- a/plugin/test/org/aavso/tools/vstar/external/plugin/AllTests.java
+++ b/plugin/test/org/aavso/tools/vstar/external/plugin/AllTests.java
@@ -20,6 +20,8 @@ package org.aavso.tools.vstar.external.plugin;
 
 import java.util.Locale;
 
+import org.aavso.tools.vstar.external.lib.ConvertHelperTest;
+
 import junit.framework.Test;
 import junit.framework.TestSuite;
 
@@ -33,7 +35,9 @@ public class AllTests {
 
 		// $JUnit-BEGIN$
 		suite.addTestSuite(PluginTest.class);
-        suite.addTestSuite(PiecewiseLinearModelTest.class);
+		suite.addTestSuite(PiecewiseLinearModelTest.class);
+		suite.addTestSuite(ConvertHelperTest.class);
+		suite.addTestSuite(HipparcosLoadTest.class);
 		// $JUnit-END$
 		
 		return suite;

--- a/plugin/test/org/aavso/tools/vstar/external/plugin/HipparcosLoadTest.java
+++ b/plugin/test/org/aavso/tools/vstar/external/plugin/HipparcosLoadTest.java
@@ -1,0 +1,30 @@
+package org.aavso.tools.vstar.external.plugin;
+
+import org.aavso.tools.vstar.data.ValidObservation;
+import org.aavso.tools.vstar.input.AbstractObservationRetriever;
+import org.aavso.tools.vstar.util.Tolerance;
+
+import junit.framework.TestCase;
+
+/**
+ * Loads Hipparcos sample data via {@link ObservationSourcePluginBase#getTestRetriever}.
+ */
+public class HipparcosLoadTest extends TestCase {
+
+    private static class HipparcosTestAccess extends HipparcosObservationSource {
+        AbstractObservationRetriever load(String[] lines) throws Exception {
+            return getTestRetriever(lines, "HIP");
+        }
+    }
+
+    public void testLoadSampleLine() throws Exception {
+        HipparcosTestAccess plugin = new HipparcosTestAccess();
+        AbstractObservationRetriever retriever = plugin
+                .load(new String[] { "JD\n", "10000|10.0|0|0\n" });
+        assertEquals(0, retriever.getInvalidObservations().size());
+        assertEquals(1, retriever.getValidObservations().size());
+        ValidObservation ob = retriever.getValidObservations().get(0);
+        assertTrue(Tolerance.areClose(2450000.0, ob.getJD(), 1e-6, true));
+        assertTrue(Tolerance.areClose(10.0, ob.getMag(), 1e-6, true));
+    }
+}

--- a/plugin/test/org/aavso/tools/vstar/external/plugin/PiecewiseLinearModelTest.java
+++ b/plugin/test/org/aavso/tools/vstar/external/plugin/PiecewiseLinearModelTest.java
@@ -23,6 +23,8 @@ import java.util.List;
 import org.aavso.tools.vstar.data.DateInfo;
 import org.aavso.tools.vstar.data.Magnitude;
 import org.aavso.tools.vstar.data.ValidObservation;
+import org.aavso.tools.vstar.exception.AlgorithmError;
+import org.aavso.tools.vstar.external.lib.PiecewiseLinearModel;
 import org.aavso.tools.vstar.external.lib.PiecewiseLinearModel.LinearFunction;
 import org.aavso.tools.vstar.external.lib.PiecewiseLinearModel.PiecewiseLinearFunction;
 import org.aavso.tools.vstar.ui.model.plot.JDCoordSource;
@@ -48,6 +50,17 @@ public class PiecewiseLinearModelTest extends TestCase {
         assertTrue(Tolerance.areClose(m, function.slope(), DELTA, true));
         assertTrue(Tolerance.areClose(10 - (m * 2459645), function.yIntercept(), DELTA, true));
         assertTrue(Tolerance.areClose(m * 2459642 + function.yIntercept(), function.value(2459642), DELTA, true));
+    }
+
+    public void testPiecewiseLinearModelExecute() throws AlgorithmError {
+        List<ValidObservation> meanObs = getTestMeanObs();
+        List<ValidObservation> obs = getTestObs();
+
+        PiecewiseLinearModel model = new PiecewiseLinearModel(obs, meanObs);
+        model.execute();
+
+        assertEquals(obs.size(), model.getFit().size());
+        assertEquals(obs.size(), model.getResiduals().size());
     }
 
     public void testPiecewiseLinearFunction() {


### PR DESCRIPTION
Add IPlugin.test() implementations and JUnit tests for observation sources, filters, and shared libraries; run the full AllTests suite in plugin builds.