### PR TITLE
#605: make VeLa numeric literals locale-independent

### DIFF
--- a/.github/workflows/snapshot-release.yml
+++ b/.github/workflows/snapshot-release.yml
@@ -1,16 +1,11 @@
-# This workflow will build a Java project with Ant and create a daily 
-# release of the bash and win targets.
+# This workflow will build a Java project with Ant, create a daily release of the 
+# bash and win targets, update the grammar railroad diagram navigable from the wiki.
 #
 # For more information see:
 # - https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-ant
 # - https://github.com/AAVSO/VStar/issues/340
 
 name: Snapshot release 
-
-#on:
-#  schedule:
-#     # every day at 0845 GMT
-#    - cron: '45 08 * * *'
 
 on:
   push:
@@ -44,9 +39,6 @@ jobs:
     - name: Build win archive
       run:
         ant -noinput -buildfile build.xml win
-#    - name: Build mac archive
-#      run:
-#        ant -noinput -buildfile build.xml mac
     - name: Build plugins archive
       run: |
         cd plugin

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,6 +1,6 @@
 [![VStar Unit Tests](https://github.com/AAVSO/VStar/actions/workflows/vstar-UT.yml/badge.svg)](https://github.com/AAVSO/VStar/actions/workflows/vstar-UT.yml)
 [![Plug-in Unit Tests](https://github.com/AAVSO/VStar/actions/workflows/plugin-UT.yml/badge.svg)](https://github.com/AAVSO/VStar/actions/workflows/plugin-UT.yml)
-[![Snapshot release](https://github.com/AAVSO/VStar/actions/workflows/daily-release.yml/badge.svg)](https://github.com/AAVSO/VStar/actions/workflows/daily-release.yml)
+[![Snapshot release](https://github.com/AAVSO/VStar/actions/workflows/daily-release.yml/badge.svg)](https://github.com/AAVSO/VStar/actions/workflows/snapshot-release.yml)
 [![CodeQL](https://github.com/AAVSO/VStar/actions/workflows/codeql.yml/badge.svg)](https://github.com/AAVSO/VStar/actions/workflows/codeql.yml)
 [![SpotBugs](https://github.com/AAVSO/VStar/actions/workflows/spotbugs.yml/badge.svg)](https://github.com/AAVSO/VStar/actions/workflows/spotbugs.yml)
 [![Checker Framework](https://github.com/AAVSO/VStar/actions/workflows/checkerframework.yml/badge.svg)](https://github.com/AAVSO/VStar/actions/workflows/checkerframework.yml)

--- a/src/org/aavso/tools/vstar/vela/ExpressionVisitor.java
+++ b/src/org/aavso/tools/vstar/vela/ExpressionVisitor.java
@@ -17,10 +17,6 @@
  */
 package org.aavso.tools.vstar.vela;
 
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.text.ParsePosition;
-import java.util.Locale;
 import java.util.Optional;
 
 import org.aavso.tools.vstar.vela.VeLaParser.AdditiveExpressionContext;
@@ -439,45 +435,22 @@ public class ExpressionVisitor extends VeLaBaseVisitor<AST> {
      * value is present, throw a NumberFormatException. The string is first trimmed
      * of leading and trailing whitespace.
      *
+     * VeLa accepts both '.' and ',' as the decimal point (see the POINT fragment in
+     * VeLa.g4). A comma can only ever appear inside a REAL token as the decimal
+     * point: lists and call arguments are whitespace-separated, comma's only
+     * grammatical role is the POINT fragment, and a REAL admits a single separator.
+     * We can therefore normalise ',' to '.' losslessly and parse in a
+     * locale-independent way, so that the same VeLa code behaves identically in
+     * every locale (issue #605).
+     *
      * @param str The string that (hopefully) contains a number.
-     * @return The double value corresponding to the initial parseable portion of
-     *         the string.
+     * @return The double value corresponding to the string.
      * @throws NumberFormatException If no valid double value is present.
      */
     private double parseDouble(String str) throws NumberFormatException {
         if (str == null) {
             throw new NumberFormatException("String was null");
-        } else {
-            DecimalFormatSymbols dfs = new DecimalFormatSymbols(Locale.getDefault());
-            dfs.setExponentSeparator("E"); // may differ for some locales
-            dfs.setMinusSign('-'); // "nn" locale fails without this
-            DecimalFormat FORMAT = new DecimalFormat("", dfs);
-            FORMAT.setGroupingUsed(false); // Suppress grouping (to avoid grouping symbol ambiguity)
-            ParsePosition parsePosition = new ParsePosition(0);
-
-            str = str.trim();
-
-            if (str.contains("e")) {
-                // Convert exponential indicator to parsable form
-                str = str.toUpperCase();
-            }
-
-            // We use parsePosition to be sure that the input string is parsed to the end.
-            // Without parsePosition the parse() method may return a valid result for
-            // a part of the string (parsing is terminated at the first invalid symbol).
-            // For example, a string "1.234" parsed under uk_UA, fr_FR, or other European
-            // locales
-            // without parsePosition is converted to 1. If parsePosition is used, we can
-            // check
-            // if the string is parsed completely and throw an exception if not.
-            Number number = FORMAT.parse(str, parsePosition);
-            if (number == null) {
-                throw new NumberFormatException("Failed to parse: " + str);
-            }
-            if (parsePosition.getIndex() < str.length()) {
-                throw new NumberFormatException("Failed to parse the full string: " + str);
-            }
-            return number.doubleValue();
         }
+        return Double.parseDouble(str.trim().replace(',', '.'));
     }
 }

--- a/test/org/aavso/tools/vstar/vela/VeLaTest.java
+++ b/test/org/aavso/tools/vstar/vela/VeLaTest.java
@@ -125,6 +125,24 @@ public class VeLaTest extends TestCase implements WithQuickTheories {
         commonNumericLocaleTest("3.141592E-1", 0.314159, 1e-6);
     }
 
+    // issue #605: the same VeLa source must evaluate to the same value in every
+    // locale. Unlike commonNumericLocaleTest, the program text is NOT rewritten
+    // with the locale-specific separator: a '.' literal must work in a
+    // comma-decimal locale and a ',' literal must work in a dot-decimal locale.
+
+    public void testDecimalPointPortableAcrossLocales() {
+        commonNumericPortabilityTest("4.2", 4.2, 1e-9);
+    }
+
+    public void testDecimalCommaPortableAcrossLocales() {
+        commonNumericPortabilityTest("4,2", 4.2, 1e-9);
+    }
+
+    public void testExponentPortableAcrossLocales() {
+        commonNumericPortabilityTest("3.141592E5", 314159.2, 1e-6);
+        commonNumericPortabilityTest("3,141592E5", 314159.2, 1e-6);
+    }
+
     public void testAddition() {
         Operand result = vela.expressionToOperand("2457580.25+1004");
         assertTrue(Tolerance.areClose(2458584.25, result.doubleVal(), DELTA, true));
@@ -2191,26 +2209,73 @@ public class VeLaTest extends TestCase implements WithQuickTheories {
         Set<String> localesToIgnore = new HashSet<String>();
         localesToIgnore.add("ar-JO");
 
-        for (Locale locale : Locale.getAvailableLocales()) {
-            Locale.setDefault(locale);
-            if (localesToIgnore.contains(locale.toLanguageTag())) {
-                System.err.printf("** Ignoring locale: %s\n", locale.toLanguageTag());
-                continue;
+        Locale savedDefault = Locale.getDefault();
+        try {
+            for (Locale locale : Locale.getAvailableLocales()) {
+                Locale.setDefault(locale);
+                if (localesToIgnore.contains(locale.toLanguageTag())) {
+                    System.err.printf("** Ignoring locale: %s\n", locale.toLanguageTag());
+                    continue;
+                }
+                DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.getDefault());
+                char sep = symbols.getDecimalSeparator();
+                // VeLa only supports '.' and ',' as the decimal point (the POINT
+                // fragment in VeLa.g4). For locales whose decimal separator is some
+                // other character (e.g. the Arabic '\u066B'), keep '.' and just verify
+                // that a '.'-written program still parses under that default locale.
+                char velaSep = (sep == '.' || sep == ',') ? sep : '.';
+                // Use a fresh local per iteration: reassigning prog would strip all
+                // '.' after the first non-dot locale, so later locales would test an
+                // already-converted string.
+                String localisedProg = prog.replace('.', velaSep);
+                Optional<Operand> result = Optional.ofNullable(null);
+                try {
+                    result = vela.program(localisedProg);
+                    assertTrue(result.isPresent());
+                    assertTrue(Tolerance.areClose(expected, result.get().doubleVal(), tolerance, true));
+                } catch (NumberFormatException e) {
+                    // allows us to debug a failure more easily via breakpoints
+                    Operand val = result.get();
+                    fail(String.format("Number format exception thrown: locale=%s, result=%s", locale.toLanguageTag(),
+                            val.toHumanReadableString()));
+                }
             }
-            DecimalFormatSymbols symbols = new DecimalFormatSymbols(Locale.getDefault());
-            char sep = symbols.getDecimalSeparator();
-            prog = prog.replace('.', sep);
-            Optional<Operand> result = Optional.ofNullable(null);
-            try {
-                result = vela.program(prog);
-                assertTrue(result.isPresent());
-                assertTrue(Tolerance.areClose(expected, result.get().doubleVal(), tolerance, true));
-            } catch (NumberFormatException e) {
-                // allows us to debug a failure more easily via breakpoints
-                Operand val = result.get();
-                fail(String.format("Number format exception thrown: locale=%s, result=%s", locale.toLanguageTag(),
-                        val.toHumanReadableString()));
+        } finally {
+            Locale.setDefault(savedDefault);
+        }
+    }
+
+    /**
+     * Given a VeLa program, test that it evaluates to the same value in every
+     * available locale, WITHOUT rewriting the decimal separator. This verifies the
+     * portability guarantee of issue #605: a literal written with '.' must work in
+     * a comma-decimal locale and a literal written with ',' must work in a
+     * dot-decimal locale.
+     *
+     * @param prog      A string containing arbitrary VeLa code.
+     * @param expected  The expected numeric result.
+     * @param tolerance The comparison tolerance.
+     */
+    private void commonNumericPortabilityTest(String prog, double expected, double tolerance) {
+        Locale savedDefault = Locale.getDefault();
+        try {
+            for (Locale locale : Locale.getAvailableLocales()) {
+                Locale.setDefault(locale);
+                Optional<Operand> result = Optional.ofNullable(null);
+                try {
+                    result = vela.program(prog);
+                    assertTrue(String.format("No result: locale=%s, prog=%s", locale.toLanguageTag(), prog),
+                            result.isPresent());
+                    assertTrue(String.format("Wrong value: locale=%s, prog=%s, result=%s", locale.toLanguageTag(), prog,
+                            result.get().toHumanReadableString()),
+                            Tolerance.areClose(expected, result.get().doubleVal(), tolerance, true));
+                } catch (NumberFormatException e) {
+                    fail(String.format("Number format exception thrown: locale=%s, prog=%s", locale.toLanguageTag(),
+                            prog));
+                }
             }
+        } finally {
+            Locale.setDefault(savedDefault);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #605. VeLa accepts both `.` and `,` as the decimal point, but `parseDouble()` interpreted the literal through `Locale.getDefault()`, so the *same* code worked in one locale and failed in another (e.g. `-4.2` vs `-4,2`).

A comma can only ever appear **inside** a `REAL` token as the decimal point: lists and call arguments are whitespace-separated, comma's only grammatical role is the `POINT` fragment (`POINT: PERIOD | COMMA`), and a `REAL` admits a single separator. So we can normalise `,` → `.` losslessly and parse in a locale-independent way, keeping the original flexibility of localised numbers while making the same source behave identically everywhere.

## Changes

- **`ExpressionVisitor.parseDouble`**: normalise `,` → `.` and parse with `Double.parseDouble`. Removes the locale-dependent `DecimalFormat` / `DecimalFormatSymbols` / `ParsePosition` machinery and the `setExponentSeparator` / `setMinusSign` workarounds (`Double.parseDouble` already handles `e`/`E`, a leading `.`, etc.).
- **`VeLaTest.commonNumericLocaleTest`**: fix a latent bug where the `prog` parameter was reassigned inside the locale loop (stripping all `.` after the first non-dot locale, so later locales tested an already-converted string); restore the default locale in a `finally`; and only substitute decimal separators VeLa actually supports (`.`/`,`), otherwise verify a `.`-written program still parses under that default locale.
- **New portability tests**: `testDecimalPointPortableAcrossLocales`, `testDecimalCommaPortableAcrossLocales`, `testExponentPortableAcrossLocales` (plus a `commonNumericPortabilityTest` helper) confirm that `.` and `,` literals evaluate identically across all available locales without rewriting the source.

## Notes

- This keeps `.` and `,` as the only supported decimal points (by grammar design). Locales whose separator is some other character (e.g. Arabic `٫`, U+066B) aren't lexable as numbers and are out of scope here — handling them would require a grammar change.
- Relies on `,` keeping its current role (decimal point only). If a future change gives comma a syntactic meaning (e.g. an optional list/argument separator), that decision should come first.

## Test plan

- [x] `ant test` / `VeLaTest` — all 222 tests pass
- [x] Verified under both the default (CLDR) and `COMPAT,CLDR` locale providers
- [x] `4.2` and `4,2` both evaluate to `4.2` regardless of default locale